### PR TITLE
Fix Dotenv v3 usage

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -38,7 +38,7 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 		$this->io       = $io;
 
 		if ( file_exists( getcwd() . DIRECTORY_SEPARATOR . '.env' ) ) {
-			$dotenv = new Dotenv( getcwd() );
+			$dotenv = Dotenv::create( getcwd() );
 			$dotenv->load();
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
   "name": "junaidbhura/composer-wp-pro-plugins",
   "type": "composer-plugin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "require": {
-      "vlucas/phpdotenv": "^3.0.0",
+      "vlucas/phpdotenv": "^3.0",
       "composer-plugin-api": "^1.1"
   },
   "authors": [


### PR DESCRIPTION
Fixed:
- Replaced occurrence of `new Dotenv(…)` with `Dotenv::create(…)`
- Loosened version constraint on `vlucas/phpdotenv`

Changed:
- Bumped version to 1.0.7