### PR TITLE
Support "auth.json" file, add EDD helper, and introduce SearchWP support

### DIFF
--- a/Http.php
+++ b/Http.php
@@ -39,27 +39,23 @@ class Http {
 	/**
 	 * Get an EDD download URL.
 	 *
-	 * @param string $url      The URL of the plugin's EDD-powered website.
-	 * @param string $itemName The name of the plugin to be downloaded.
-	 * @param string $key      The valid license key.
-	 * @param string $version  The version to request.
-	 * @param string $siteUrl  The user's authorised website.
+	 * @param string $url        The URL of the plugin's EDD-powered website.
+	 * @param string $itemName   The name of the plugin to be downloaded.
+	 * @param string $licenseKey The valid license key.
+	 * @param string $version    The version to request.
+	 * @param string $siteUrl    The user's authorised website.
 	 *
 	 * @return string
 	 */
-	public function getEddUrl( string $url, string $itemName, string $key, string $version, string $siteUrl ) {
+	public function getEddUrl( string $url, string $itemName, string $licenseKey, string $version, string $siteUrl ) {
 		$response = json_decode( $this->post( $url, array(
 			'edd_action' => 'get_version',
 			'item_name'  => $itemName,
-			'license'    => $key,
+			'license'    => $licenseKey,
 			'version'    => $version,
 			'url'        => $siteUrl,
 		) ), true );
 
-		if ( empty( $response['download_link'] ) ) {
-			return '';
-		}
-
-		return $response['download_link'];
+		return $response['download_link'] ?? '';
 	}
 }

--- a/Http.php
+++ b/Http.php
@@ -36,4 +36,30 @@ class Http {
 		return $response;
 	}
 
+	/**
+	 * Get an EDD download URL.
+	 *
+	 * @param string $url      The URL of the plugin's EDD-powered website.
+	 * @param string $itemName The name of the plugin to be downloaded.
+	 * @param string $key      The valid license key.
+	 * @param string $version  The version to request.
+	 * @param string $siteUrl  The user's authorised website.
+	 *
+	 * @return string
+	 */
+	public function getEddUrl( string $url, string $itemName, string $key, string $version, string $siteUrl ) {
+		$response = json_decode( $this->post( $url, array(
+			'edd_action' => 'get_version',
+			'item_name'  => $itemName,
+			'license'    => $key,
+			'version'    => $version,
+			'url'        => $siteUrl,
+		) ), true );
+
+		if ( empty( $response['download_link'] ) ) {
+			return '';
+		}
+
+		return $response['download_link'];
+	}
 }

--- a/Installer.php
+++ b/Installer.php
@@ -94,6 +94,10 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 				$plugin = new Plugins\PolylangPro( $package->getPrettyVersion(), $this->config );
 				break;
 
+			case 'junaidbhura/searchwp':
+				$plugin = new Plugins\SearchWp( $package->getPrettyVersion(), $this->config );
+				break;
+
 			case 'junaidbhura/wp-all-import-pro':
 			case 'junaidbhura/wp-all-export-pro':
 				$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), $this->config, $this->getSlug( $package_name ) );

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Next, define the repositories you would like to install. You must add at least t
 Add the following to your composer.json file:
 
 ```json
-"repositories":[
+"repositories": [
   {
-    "type":"vcs",
-    "url":"https://github.com/junaidbhura/composer-wp-pro-plugins"
+    "type": "vcs",
+    "url": "https://github.com/junaidbhura/composer-wp-pro-plugins"
   },
   {
     "type": "package",

--- a/README.md
+++ b/README.md
@@ -1,26 +1,60 @@
-# Composer Installer for Pro WordPress Plugins.
+# Composer Installer for Pro WordPress Plugins
+
+Install premium/paid WordPress plugins through Composer, using your license keys.
+
+## Supported Plugins
 
 Currently supports:
 
 1. Advanced Custom Fields Pro
-1. Gravity Forms and Add-Ons
+1. Gravity Forms (and add-ons)
 1. Polylang Pro
-1. WP All Import / Export Pro
+1. SearchWP
+1. WP All Import / Export Pro (and add-ons)
 
 ## Usage
 
-Create a `.env` file in the root of your WordPress site, where the composer.json file lives, which has all the license keys and settings:
+### Define Credentials
+
+Create an `auth.json` file in your project's root (next to the `composer.json` file) or in your global `COMPOSER_HOME` directory (often `~/.composer`). (You may already have one from [configuring basic auth or GitHub credentials](https://getcomposer.org/doc/articles/http-basic-authentication.md).) For automated environments, you can also [pass the JSON into the `COMPOSER_AUTH` environment variable](https://getcomposer.org/doc/03-cli.md#composer-auth).
+
+In the auth.json file, add the credentials you need within a `composer-wp-pro-plugins` object, making sure to format your JSON correctly to preserve credentials for other authentication methods.
+
+```json
+{
+  "composer-wp-pro-plugins": {
+    "acf-pro-key": "",
+    "gravity-forms-key": "",
+    "polylang-pro-key": "",
+    "polylang-pro-url": "",
+    "searchwp-key": "",
+    "searchwp-url": "",
+    "wp-all-import-pro-key": "",
+    "wp-all-import-pro-url": "",
+    "wp-all-export-pro-key": "",
+    "wp-all-export-pro-url": "",
+    ...
+  },
+  "additional-auth-methods": {
+    ...
+  }
+}
+```
+
+This library previously recommended using a `.env` file to store credentials, and still supports this feature for backward compatibility. If you prefer this approach, create a `.env` file in the root of your WordPress site (adjacent to the `composer.json` file), with all the license keys and settings you need.
+
+The keys are the same as in the `auth.json` file, however they are uppercased and use underscores instead of hyphens:
 
 ```
-ACF_PRO_KEY="<acf_pro_license_key>"
-GRAVITY_FORMS_KEY="<gravity_forms_license_key>"
-POLYLANG_PRO_KEY="<polylang_pro_license_key>"
-POLYLANG_PRO_URL="<registered_url_for_polylang_pro>"
-WP_ALL_IMPORT_PRO_KEY="<wp_all_import_license_key>"
-WP_ALL_IMPORT_PRO_URL="<registered_url_for_wpai_pro>"
-WP_ALL_EXPORT_PRO_KEY="<wp_all_export_license_key>"
-WP_ALL_EXPORT_PRO_URL="<registered_url_for_wpae_pro>"
+ACF_PRO_KEY=""
+GRAVITY_FORMS_KEY=""
+POLYLANG_PRO_KEY=""
+...
 ```
+
+### Define Repositories
+
+Next, define the repositories you would like to install. You must add at least the VCS repository for this package, and then can choose which pro plugins you would like available.
 
 Add the following to your composer.json file:
 
@@ -69,6 +103,21 @@ Add the following to your composer.json file:
       "dist": {
         "type": "zip",
         "url": "https://www.gravityforms.com"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/searchwp",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://searchwp.com"
       },
       "require": {
         "junaidbhura/composer-wp-pro-plugins": "*"
@@ -136,11 +185,19 @@ Add the following to your composer.json file:
     }
   }
 ],
+```
+
+## Install Plugins
+
+Finally, you can require the dependencies you need, either through the JSON example below, or by running `composer require junaidbhura/plugin-name` on your command line.
+
+```json
 "require": {
   "junaidbhura/advanced-custom-fields-pro": "*",
   "junaidbhura/gravityforms": "*",
   "junaidbhura/gravityformspolls": "*",
   "junaidbhura/polylang-pro": "*",
+  "junaidbhura/searchwp": "*",
   "junaidbhura/wp-all-import-pro": "*",
   "junaidbhura/wp-all-export-pro": "*",
   "junaidbhura/wpai-acf-add-on": "*"
@@ -149,7 +206,7 @@ Add the following to your composer.json file:
 
 ## Gravity Forms Add-Ons
 
-You can use any Gravity Forms add-on by simply adding it's slug like so:
+You can use any Gravity Forms add-on by simply adding its slug, like so:
 
 `junaidbhura/<plugin-slug>`
 
@@ -161,7 +218,7 @@ Here's a list of all Gravity Forms add-on slugs: [https://docs.gravityforms.com/
 
 ## WP All Import Pro Add-Ons
 
-You can use any WP All Import Pro add-on by simply adding it's slug like so:
+You can use any WP All Import Pro add-on by simply adding its slug, like so:
 
 `junaidbhura/<plugin-slug>`
 

--- a/plugins/AcfPro.php
+++ b/plugins/AcfPro.php
@@ -10,7 +10,7 @@ namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 /**
  * AcfPro class.
  */
-class AcfPro {
+class AcfPro extends Plugin implements PluginInterface {
 
 	/**
 	 * The version number of the plugin to download.
@@ -20,12 +20,26 @@ class AcfPro {
 	protected $version = '';
 
 	/**
+	 * The composer-wp-pro-plugins config array for the Composer instance.
+	 *
+	 * @var array Config array.
+	 */
+	protected $config = [];
+
+	/**
+	 * The slug of which plugin to download.
+	 *
+	 * @var string Plugin slug.
+	 */
+	protected $slug = '';
+
+	/**
 	 * AcfPro constructor.
 	 *
 	 * @param string $version
 	 */
-	public function __construct( $version = '' ) {
-		$this->version = $version;
+	public function __construct( string $version, array $config ) {
+		parent::__construct( $version, $config );
 	}
 
 	/**
@@ -34,7 +48,9 @@ class AcfPro {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		return 'https://connect.advancedcustomfields.com/index.php?p=pro&a=download&k=' . getenv( 'ACF_PRO_KEY' ) . '&t=' . $this->version;
+		$licenseKey = $this->getConfigValue( 'acf-pro-key', 'ACF_PRO_KEY' );
+
+		return 'https://connect.advancedcustomfields.com/index.php?p=pro&a=download&k=' . $licenseKey . '&t=' . $this->version;
 	}
 
 }

--- a/plugins/GravityForms.php
+++ b/plugins/GravityForms.php
@@ -12,7 +12,7 @@ use Junaidbhura\Composer\WPProPlugins\Http;
 /**
  * GravityForms class.
  */
-class GravityForms {
+class GravityForms extends Plugin implements PluginInterface {
 
 	/**
 	 * The version number of the plugin to download.
@@ -20,6 +20,13 @@ class GravityForms {
 	 * @var string Version number.
 	 */
 	protected $version = '';
+
+	/**
+	 * The composer-wp-pro-plugins config array for the Composer instance.
+	 *
+	 * @var array Config array.
+	 */
+	protected $config = [];
 
 	/**
 	 * The slug of which Gravity Forms plugin to download.
@@ -34,9 +41,8 @@ class GravityForms {
 	 * @param string $version
 	 * @param string $slug
 	 */
-	public function __construct( $version = '', $slug = 'gravityforms' ) {
-		$this->version = $version;
-		$this->slug    = $slug;
+	public function __construct( string $version, array $config, string $slug = 'gravityforms' ) {
+		parent::__construct( $version, $config, $slug );
 	}
 
 	/**
@@ -45,11 +51,15 @@ class GravityForms {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
+		$key = $this->getConfigValue( 'gravity-forms-key', 'GRAVITY_FORMS_KEY' );
+
 		$http     = new Http();
-		$response = unserialize( $http->post( 'https://www.gravityhelp.com/wp-content/plugins/gravitymanager/api.php?op=get_plugin&slug=' . $this->slug . '&key=' . getenv( 'GRAVITY_FORMS_KEY' ) ) );
+		$response = unserialize( $http->post( 'https://www.gravityhelp.com/wp-content/plugins/gravitymanager/api.php?op=get_plugin&slug=' . $this->slug . '&key=' . $key ) );
+
 		if ( ! empty( $response['download_url_latest'] ) ) {
 			return str_replace( 'http://', 'https://', $response['download_url_latest'] );
 		}
+
 		return '';
 	}
 

--- a/plugins/Plugin.php
+++ b/plugins/Plugin.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Base Plugin class.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+class Plugin {
+
+	/**
+	 * The version number of the plugin to download.
+	 *
+	 * @var string Version number.
+	 */
+	protected $version = '';
+
+	/**
+	 * The composer-wp-pro-plugins config array for the Composer instance.
+	 *
+	 * @var array Config array.
+	 */
+	protected $config = [];
+
+	/**
+	 * The slug of which plugin to download.
+	 *
+	 * @var string Plugin slug.
+	 */
+	protected $slug = '';
+
+	/**
+	 * Construct the plugin.
+	 *
+	 * @return void
+	 */
+	public function __construct( string $version, array $config, string $slug = '' ) {
+		$this->version = $version;
+		$this->config  = $config;
+		$this->slug    = $slug;
+	}
+
+	/**
+	 * Fetch a config value with a fallback to .env if necessary.
+	 *
+	 * @return string;
+	 */
+	public function getConfigValue( string $key, string $envKey ) {
+		return $config[ $key ] ?? getenv( $envKey );
+	}
+
+}

--- a/plugins/Plugin.php
+++ b/plugins/Plugin.php
@@ -47,7 +47,7 @@ class Plugin {
 	 * @return string;
 	 */
 	public function getConfigValue( string $key, string $envKey ) {
-		return $config[ $key ] ?? getenv( $envKey );
+		return $this->config[ $key ] ?? getenv( $envKey );
 	}
 
 }

--- a/plugins/PluginInterface.php
+++ b/plugins/PluginInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Base Plugin class.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+interface PluginInterface {
+
+	/**
+	 * Get the download URL for this plugin.
+	 *
+	 * @return string
+	 */
+	public function getDownloadUrl();
+
+}

--- a/plugins/PolylangPro.php
+++ b/plugins/PolylangPro.php
@@ -12,7 +12,7 @@ use Junaidbhura\Composer\WPProPlugins\Http;
 /**
  * PolylangPro class.
  */
-class PolylangPro {
+class PolylangPro extends Plugin implements PluginInterface {
 
 	/**
 	 * The version number of the plugin to download.
@@ -22,12 +22,27 @@ class PolylangPro {
 	protected $version = '';
 
 	/**
+	 * The composer-wp-pro-plugins config array for the Composer instance.
+	 *
+	 * @var array Config array.
+	 */
+	protected $config = [];
+
+	/**
+	 * The slug of which plugin to download.
+	 *
+	 * @var string Plugin slug.
+	 */
+	protected $slug = '';
+
+	/**
 	 * PolylangPro constructor.
 	 *
 	 * @param string $version
+	 * @param array $config
 	 */
-	public function __construct( $version = '' ) {
-		$this->version = $version;
+	public function __construct( string $version, array $config ) {
+		parent::__construct( $version, $config );
 	}
 
 	/**
@@ -36,18 +51,13 @@ class PolylangPro {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		$http     = new Http();
-		$response = json_decode( $http->post( 'https://polylang.pro', array(
-			'edd_action' => 'get_version',
-			'license'    => getenv( 'POLYLANG_PRO_KEY' ),
-			'item_name'  => 'Polylang Pro',
-			'url'        => getenv( 'POLYLANG_PRO_URL' ),
-			'version'    => $this->version,
-		) ), true );
-		if ( ! empty( $response['download_link'] ) ) {
-			return $response['download_link'];
-		}
-		return '';
+		// Get the config settings.
+		$licenseKey = $this->getConfigValue( 'polylang-pro-key', 'POLYLANG_PRO_KEY' );
+		$siteUrl    = $this->getConfigValue( 'polylang-pro-url', 'POLYLANG_PRO_URL' );
+
+		$http = new Http();
+
+		return $http->getEddUrl( 'https://polylang.pro', 'Polylang Pro', $licenseKey, $this->version, $siteUrl );
 	}
 
 }

--- a/plugins/SearchWp.php
+++ b/plugins/SearchWp.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Polylang Pro Plugin.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+use Junaidbhura\Composer\WPProPlugins\Http;
+
+/**
+ * PolylangPro class.
+ */
+class SearchWp extends Plugin implements PluginInterface {
+
+	/**
+	 * The version number of the plugin to download.
+	 *
+	 * @var string Version number.
+	 */
+	protected $version = '';
+
+	/**
+	 * The composer-wp-pro-plugins config array for the Composer instance.
+	 *
+	 * @var array Config array.
+	 */
+	protected $config = [];
+
+	/**
+	 * The slug of which plugin to download.
+	 *
+	 * @var string Plugin slug.
+	 */
+	protected $slug = '';
+
+	/**
+	 * PolylangPro constructor.
+	 *
+	 * @param string $version
+	 * @param array $config
+	 */
+	public function __construct( string $version, array $config ) {
+		parent::__construct( $version, $config );
+	}
+
+	/**
+	 * Get the download URL for this plugin.
+	 *
+	 * @return string
+	 */
+	public function getDownloadUrl() {
+		$http = new Http();
+
+		// Get the config settings.
+		$licenseKey = $this->getConfigValue( 'searchwp-key', 'SEARCHWP_KEY' );
+		$siteUrl    = $this->getConfigValue( 'searchwp-url', 'SEARCHWP_URL' );
+
+		return $http->getEddUrl( 'https://searchwp.com', 'SearchWP', $licenseKey, $this->version, $siteUrl );
+	}
+
+}

--- a/plugins/WpAiPro.php
+++ b/plugins/WpAiPro.php
@@ -12,7 +12,7 @@ use Junaidbhura\Composer\WPProPlugins\Http;
 /**
  * WpAiPro class.
  */
-class WpAiPro {
+class WpAiPro extends Plugin implements PluginInterface {
 
 	/**
 	 * The version number of the plugin to download.
@@ -20,6 +20,13 @@ class WpAiPro {
 	 * @var string Version number.
 	 */
 	protected $version = '';
+
+	/**
+	 * The composer-wp-pro-plugins config array for the Composer instance.
+	 *
+	 * @var array Config array.
+	 */
+	protected $config = [];
 
 	/**
 	 * The slug of which plugin to download.
@@ -34,9 +41,8 @@ class WpAiPro {
 	 * @param string $version
 	 * @param string $slug
 	 */
-	public function __construct( $version = '', $slug = 'wp-all-import-pro' ) {
-		$this->version = $version;
-		$this->slug    = $slug;
+	public function __construct( string $version, array $config, string $slug = 'wp-all-import-pro' ) {
+		parent::__construct( $version, $config, $slug );
 	}
 
 	/**
@@ -46,12 +52,12 @@ class WpAiPro {
 	 */
 	public function getDownloadUrl() {
 		if ( 'wp-all-export-pro' === $this->slug ) {
-			$license = getenv( 'WP_ALL_EXPORT_PRO_KEY' );
-			$url     = getenv( 'WP_ALL_EXPORT_PRO_URL' );
-			$name    = 'WP All Export';
+			$licenseKey = $this->getConfigValue( 'wp-all-export-pro-key', 'WP_ALL_EXPORT_PRO_KEY' );
+			$siteUrl    = $this->getConfigValue( 'wp-all-export-pro-url', 'WP_ALL_EXPORT_PRO_URL' );
+			$name       = 'WP All Export';
 		} else {
-			$license = getenv( 'WP_ALL_IMPORT_PRO_KEY' );
-			$url     = getenv( 'WP_ALL_IMPORT_PRO_URL' );
+			$licenseKey = $this->getConfigValue( 'wp-all-import-pro-key', 'WP_ALL_IMPORT_PRO_KEY' );
+			$siteUrl    = $this->getConfigValue( 'wp-all-import-pro-url', 'WP_ALL_IMPORT_PRO_URL' );
 
 			switch ( $this->slug ) {
 				case 'wpai-acf-add-on':
@@ -71,18 +77,7 @@ class WpAiPro {
 			}
 		}
 
-		$http     = new Http();
-		$response = json_decode( $http->post( 'https://www.wpallimport.com', array(
-			'edd_action' => 'get_version',
-			'license'    => $license,
-			'item_name'  => $name,
-			'url'        => $url,
-			'version'    => $this->version,
-		) ), true );
-		if ( ! empty( $response['download_link'] ) ) {
-			return $response['download_link'];
-		}
-		return '';
+		return $http->getEddUrl( 'https://www.wpallimport.com', $name, $licenseKey, $this->version, $siteUrl );
 	}
 
 }


### PR DESCRIPTION
This PR accomplishes a few things:

1. It fixes #8 by adding support for Composer's native `auth.json` (with a fallback to `.env` to preserve backward compatibility) through a `getConfigValue` helper in a new Plugin base class. The `auth.json` file ([which can be located in a project's root directory, globally in your `COMPOSER_HOME` directory](https://getcomposer.org/doc/articles/http-basic-authentication.md), or [passed as a `COMPOSER_AUTH` env variable](https://getcomposer.org/doc/03-cli.md#composer-auth)) should be formatted as such:
```json
{
  "composer-wp-pro-plugins": {
    "polylang-pro-key": "abcdefg1234567",
    "polylang-pro-url": "myauthorisedsite.com"
  },
  "additional-auth-mechanisms": {
    ...
  }
}
```
2. Introduces a helper to facilitate easier downloads from Easy Digital Downloads-based sites and refactors existing EDD-based plugins to use this helper.
3. Adds a PluginInterface class to enforce the `getDownloadUrl` function on all plugin implementations.
4. Adds support for SearchWP, via the EDD helper.