### PR TITLE
Append version to dist URL to force re-download

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -79,40 +79,38 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 		$package           = $this->getPackageFromOperation( $event->getOperation() );
 		$plugin            = false;
 		$package_name      = $package->getName();
-		$package_version   = $package->getPrettyVersion();
 
 		switch ( $package_name ) {
 
 			case 'junaidbhura/advanced-custom-fields-pro':
-				$plugin = new Plugins\AcfPro( $package_version );
+				$plugin = new Plugins\AcfPro( $package->getPrettyVersion() );
 				break;
 
 			case 'junaidbhura/polylang-pro':
-				$plugin = new Plugins\PolylangPro( $package_version );
+				$plugin = new Plugins\PolylangPro( $package->getPrettyVersion() );
 				break;
 
 			case 'junaidbhura/wp-all-import-pro':
 			case 'junaidbhura/wp-all-export-pro':
-				$plugin = new Plugins\WpAiPro( $package_version, str_replace( 'junaidbhura/', '', $package_name ) );
+				$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
 				break;
 
 			default:
 				if ( 0 === strpos( $package_name, 'junaidbhura/gravityforms' ) ) {
-					$plugin = new Plugins\GravityForms( $package_version, str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\GravityForms( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpai-' ) ) {
-					$plugin = new Plugins\WpAiPro( $package_version, str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
 				}
 
 		}
 
 		if ( ! empty( $plugin ) ) {
 			$this->downloadUrl = $plugin->getDownloadUrl();
+			$package_url       = $package->getDistUrl();
+			$package_key       = sha1( $package->getUniqueName() );
 
-			$package_url = $package->getDistUrl();
-			if ( false !== strpos( $package_url, '%version%' ) ) {
-				$package->setDistUrl( str_replace( '%version%', $package_version, $package_url ) );
-			} elseif ( false === strpos( $package_url, $package_version ) ) {
-                $package->setDistUrl( $package_url . '#v' . $package_version );
+			if ( false === strpos( $package_url, $package_key ) ) {
+                $package->setDistUrl( $package_url . '#' . $package_key );
             }
 		}
 	}

--- a/Installer.php
+++ b/Installer.php
@@ -106,12 +106,13 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 
 		if ( ! empty( $plugin ) ) {
 			$this->downloadUrl = $plugin->getDownloadUrl();
-			$package_url       = $package->getDistUrl();
-			$package_key       = sha1( $package->getUniqueName() );
 
+			// Set a unique Dist URL to prevent caching.
+			$package_url = $package->getDistUrl();
+			$package_key = sha1( $package->getUniqueName() );
 			if ( false === strpos( $package_url, $package_key ) ) {
-                $package->setDistUrl( $package_url . '#' . $package_key );
-            }
+				$package->setDistUrl( $package_url . '#' . $package_key );
+			}
 		}
 	}
 

--- a/Installer.php
+++ b/Installer.php
@@ -79,33 +79,41 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 		$package           = $this->getPackageFromOperation( $event->getOperation() );
 		$plugin            = false;
 		$package_name      = $package->getName();
+		$package_version   = $package->getPrettyVersion();
 
 		switch ( $package_name ) {
 
 			case 'junaidbhura/advanced-custom-fields-pro':
-				$plugin = new Plugins\AcfPro( $package->getPrettyVersion() );
+				$plugin = new Plugins\AcfPro( $package_version );
 				break;
 
 			case 'junaidbhura/polylang-pro':
-				$plugin = new Plugins\PolylangPro( $package->getPrettyVersion() );
+				$plugin = new Plugins\PolylangPro( $package_version );
 				break;
 
 			case 'junaidbhura/wp-all-import-pro':
 			case 'junaidbhura/wp-all-export-pro':
-				$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+				$plugin = new Plugins\WpAiPro( $package_version, str_replace( 'junaidbhura/', '', $package_name ) );
 				break;
 
 			default:
 				if ( 0 === strpos( $package_name, 'junaidbhura/gravityforms' ) ) {
-					$plugin = new Plugins\GravityForms( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\GravityForms( $package_version, str_replace( 'junaidbhura/', '', $package_name ) );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpai-' ) ) {
-					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\WpAiPro( $package_version, str_replace( 'junaidbhura/', '', $package_name ) );
 				}
 
 		}
 
 		if ( ! empty( $plugin ) ) {
 			$this->downloadUrl = $plugin->getDownloadUrl();
+
+			$package_url = $package->getDistUrl();
+			if ( false !== strpos( $package_url, '%version%' ) ) {
+				$package->setDistUrl( str_replace( '%version%', $package_version, $package_url ) );
+			} elseif ( false === strpos( $package_url, $package_version ) ) {
+                $package->setDistUrl( $package_url . '#v' . $package_version );
+            }
 		}
 	}
 


### PR DESCRIPTION
## Checklist:

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.

## Description

Currently, this Composer plugin reuses the same cache key regardless of the specified package version because the package's `dist.url` does not change between version bumps.

```json
"version": "5.9.0",
"dist": {
    "type": "zip",
    "url": "https://www.advancedcustomfields.com"
}
```

Based on Composer's [documentation](https://getcomposer.org/doc/05-repositories.md#package-2) for packages that do not support Composer (and this [snippet from the source code](https://github.com/composer/composer/blob/1.10.10/src/Composer/Downloader/FileDownloader.php#L276-L285)) the `dist.url` is expected to reflect the version:

```json
"version": "5.9.0",
"dist": {
    "type": "zip",
    "url": "https://github.com/AdvancedCustomFields/acf/archive/5.9.0.zip"
}
```

This means if you were to change the `dist.url` (any random URI) along with a version bump, you'd see that Composer would use a new cache key with that new version.

Since the real archive files for these premium WordPress plugins are hidden behind complex URLs, API response keys, and often expire, this Composer plugin needs to assign some kind of unique stand-in for the `dist.url` to serve as a unique cache key for each version.

## How has this been tested?

I've tested this on a client project that uses Advanced Custom Fields Pro, Gravity Forms, and Polylang Pro.

## Types of changes

This pull request introduces a change that when a download URL is resolved, the package's unique name (name + normlized version) is appended to the internal `dist.url` (as a hashed URI fragment) in order to generate a new cache key to trigger the download of the package update.

Similar to [ffraenz/private-composer-installer](https://github.com/ffraenz/private-composer-installer/blob/v4.0.0/src/PrivateComposerInstaller/Plugin.php#L75-L85).

Resolves #7, #18