### PR TITLE
Make plugin compatible with hirak/prestissimo

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -52,7 +52,7 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 		return array(
 			PackageEvents::PRE_PACKAGE_INSTALL => 'getDownloadUrl',
 			PackageEvents::PRE_PACKAGE_UPDATE => 'getDownloadUrl',
-			PluginEvents::PRE_FILE_DOWNLOAD => 'onPreFileDownload',
+			PluginEvents::PRE_FILE_DOWNLOAD => array( 'onPreFileDownload', -1 ),
 		);
 	}
 


### PR DESCRIPTION
## Checklist:

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.

## Description

When using this Composer plugin in conjunction with [hirak/prestissimo](https://github.com/hirak/prestissimo), the download of premium plugins fails because the custom `RemoteFileSystem` is overwritten by the latter.

## How has this been tested?

I've tested this on a client project that uses Advanced Custom Fields Pro, Gravity Forms, and Polylang Pro.

## Types of changes

As both are running with the default priority (`0`), setting this one to `-1` resolves the issue (this plugin's event handler would be executed after Prestissimo, effectively replacing their custom `CurlRemoteFileSystem`).

Similar:
- PhilippBaschke/acf-pro-installer#20
- ffraenz/private-composer-installer#1 (ffraenz/private-composer-installer@fcc2195)

Resolves #1, #14

Alternatively, we could change the priority for this package to execute after Prestissimo and take advantage of the parallel downloads but we would have to perform some kind of trickery where we supply the real download URL to Prestissimo (via `$event->getProcessedUrl()`) but ensure that the package's `dist.url` does not use that URL.