### PR TITLE
Change the ACF downloads API and add support for add-ons 

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -96,7 +96,9 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 				break;
 
 			default:
-				if ( 0 === strpos( $package_name, 'junaidbhura/gravityforms' ) ) {
+				if ( 0 === strpos( $package_name, 'junaidbhura/advanced-custom-fields-' ) ) {
+					$plugin = new Plugins\AcfPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/advanced-custom-fields-', '', $package_name ) );
+				} elseif ( 0 === strpos( $package_name, 'junaidbhura/gravityforms' ) ) {
 					$plugin = new Plugins\GravityForms( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpai-' ) ) {
 					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );

--- a/plugins/AcfPro.php
+++ b/plugins/AcfPro.php
@@ -34,7 +34,7 @@ class AcfPro {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		return 'https://connect.advancedcustomfields.com/index.php?p=pro&a=download&k=' . getenv( 'ACF_PRO_KEY' ) . '&t=' . $this->version;
+		return 'https://connect.advancedcustomfields.com/v2/plugins/download?p=pro&k=' . getenv( 'ACF_PRO_KEY' ) . '&t=' . $this->version;
 	}
 
 }

--- a/plugins/AcfPro.php
+++ b/plugins/AcfPro.php
@@ -20,12 +20,20 @@ class AcfPro {
 	protected $version = '';
 
 	/**
+	 * The slug of which ACF plugin to download.
+	 *
+	 * @var string Plugin slug.
+	 */
+	protected $slug = '';
+
+	/**
 	 * AcfPro constructor.
 	 *
 	 * @param string $version
 	 */
-	public function __construct( $version = '' ) {
+	public function __construct( $version = '', $slug = 'pro' ) {
 		$this->version = $version;
+		$this->slug    = $slug;
 	}
 
 	/**
@@ -34,7 +42,7 @@ class AcfPro {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		return 'https://connect.advancedcustomfields.com/v2/plugins/download?p=pro&k=' . getenv( 'ACF_PRO_KEY' ) . '&t=' . $this->version;
+		return 'https://connect.advancedcustomfields.com/v2/plugins/download?p=' . $this->slug . '&k=' . getenv( 'ACF_PRO_KEY' ) . '&t=' . $this->version;
 	}
 
 }


### PR DESCRIPTION
## Checklist:

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [ ] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.

## Description

The current API URI, `?p=pro&a=download&k=%ACF_PRO_KEY%&t=%version%`, does not correctly support downloading older versions of ACF Pro and add-ons. The ACF account page where one can download these archives, there's a different API URI available that works as expected: `/v2/plugins/download?p=pro&k=%ACF_PRO_KEY%&t=%version%`.

Also, the plugin class does not support the download of add-ons like is supported for `GravityForms` and `WpAiPro`. At the time of writing, the available add-ons are for obsolete versions of ACF Pro (v4 and earlier).

## How has this been tested?

I've tested this on a client project that uses Advanced Custom Fields Pro.

## Types of changes

- Changed the API URI to v2 for downloading ACF Pro
- Added support for downloading ACF add-ons using the format `junaidbhura/advanced-custom-fields-<addon-slug>` (such as `junaidbhura/advanced-custom-fields-flexible-content`)
