### PR TITLE
Add support for Composer v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,36 @@
 # Composer Installer for Pro WordPress Plugins.
 
-**Important Note: Most EDD plugins, and Gravity Forms only allow getting the latest versions of their plugins, even if you specifically ask for a version.**
+A Composer plugin that makes it easy to install commercial WordPress plugins.
 
-Currently supports:
+Sensitive credentials (license keys, tokens) are read from environment variables or a `.env` file.
+
+## Supported Plugins
 
 1. Advanced Custom Fields Pro
-1. Gravity Forms and Add-Ons
-1. Polylang Pro
-1. WP All Import / Export Pro
+2. Gravity Forms / Add-Ons
+3. Polylang Pro
+4. WP All Import / Export Pro / Add-Ons
+
+## Overview
+
+> ⚠️ Note: Most EDD plugins, and Gravity Forms, only allow downloading the latest versions of their plugins, even if you request for a specific version.
+
+- Packages must use the names defined below otherwise they are ignored by this plugin.
+- When installing or updating a package, the package version is appended to the dist URL.
+  This versioned dist URL is used as the cache key to store ZIP archives of the package.
+  In Composer 1, the versioned dist URL is added to `composer.lock`.
+- Before downloading the package, the package's real download URL is retrieved and formatted with their corresponding environment variables, as defined below.
+  Environment variables will never be stored inside `composer.lock`.
+- If an environment variable can't be resolved, the download will fail and Composer will abort.
 
 ## Usage
 
-Create a `.env` file in the root of your WordPress site, where the composer.json file lives, which has all the license keys and settings:
+This Composer plugin requires [Composer](https://getcomposer.org/):
+
+- 1.0.0 and newer, or
+- 2.0.2 and newer
+
+Create a `.env` file in the root of your WordPress site, where the `composer.json` file lives, which has all the license keys and settings:
 
 ```
 ACF_PRO_KEY="<acf_pro_license_key>"
@@ -27,7 +46,7 @@ WP_ALL_EXPORT_PRO_URL="<registered_url_for_wpae_pro>"
 Add the following to your composer.json file:
 
 ```json
-"repositories":[
+"repositories": [
   {
     "type": "package",
     "package": {
@@ -145,7 +164,7 @@ Add the following to your composer.json file:
 },
 ```
 
-## Gravity Forms Add-Ons
+### Gravity Forms Add-Ons
 
 You can use any Gravity Forms add-on by simply adding it's slug like so:
 
@@ -157,7 +176,7 @@ For example:
 
 Here's a list of all Gravity Forms add-on slugs: [https://docs.gravityforms.com/gravity-forms-add-on-slugs/](https://docs.gravityforms.com/gravity-forms-add-on-slugs/)
 
-## WP All Import Pro Add-Ons
+### WP All Import Pro Add-Ons
 
 You can use any WP All Import Pro add-on by simply adding it's slug like so:
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "require": {
     "vlucas/phpdotenv": "^4.1.0",
-    "composer-plugin-api": "^1.1"
+    "composer-plugin-api": "^1.0 || ^2.0"
   },
   "authors": [
     {
@@ -19,6 +19,7 @@
     }
   },
   "extra": {
-    "class": "Junaidbhura\\Composer\\WPProPlugins\\Installer"
+    "class": "Junaidbhura\\Composer\\WPProPlugins\\Installer",
+    "plugin-modifies-downloads": true
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
   "type": "composer-plugin",
   "license": "MIT",
   "require": {
-      "vlucas/phpdotenv": "^4.1.0",
-      "composer-plugin-api": "^1.1"
+    "vlucas/phpdotenv": "^4.1.0",
+    "composer-plugin-api": "^1.1"
   },
   "authors": [
-      {
-          "name": "Junaid Bhura",
-          "email": "info@junaidbhura.com"
-      }
+    {
+      "name": "Junaid Bhura",
+      "email": "info@junaidbhura.com"
+    }
   ],
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Resolves #19

## Checklist

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## How has this been tested?

I'm testing this on a client project that uses Advanced Custom Fields Pro, Gravity Forms, and Polylang Pro.

## Types of changes

Much of the `Installer` class has been rewritten to maintain and support Composer v1 and v2.

#### Added

- [Composer 1] Method `onPrePackageInstallOrUpdateInComposer1()` on `PRE_PACKAGE_*` events to filter the dist URL for the lock file and cache key and prepare the real download URL.
- [Composer 1] Method `onPreFileDownloadInComposer1()` on `PRE_FILE_DOWNLOAD` event to replace the processed URL with the real download URL.
- [Composer 2] Method `onPreFileDownloadInComposer2()` on `PRE_FILE_DOWNLOAD` event to replace the processed URL with the real download URL and prepare the cache key.
- [Composer 2] Attribute `"extra": "plugin-modifies-downloads": true }` to `composer.json` to mark plugin as having to be installed early.
- Method `filterDistUrl()` to append the package's unique name and version to the dist URL for the dist URL and cache key.
- Method `getDownloadUrl()` to retrieve the real download URL for a supported WordPress plugin.

#### Changed

- Method `getDownloadUrl()` to no longer be used as an event listener.
- README to provide overview of plugin functionality.

#### Removed

- Method `getPackageFromOperation()` in favour of inline resolution into `onPrePackageInstallOrUpdate()`.

#### Notes

- In Composer v1, the plugin will continue to write the versioned dist URL to the lock file. This ensures the cache key matches the package version across installations and is different across updates.
- In Composer v2, the plugin ignores writing to the lock file and processes the versioned dist URL for the cache key during processing the package's real download URL.

## Todo

- [x] composer/composer#8975
- [x] composer/composer#9220 (2020-09-28)
- [x] composer/composer#9296 (2020-10-15)
- [x] composer/composer#9333 (2020-10-25)

## Related

- ffraenz/private-composer-installer#25
- pivvenit/acf-pro-installer#137