### PR TITLE
Add support for Dotenv v3, v4, and v5

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -49,9 +49,9 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 		$this->composer = $composer;
 		$this->io       = $io;
 
-		if ( file_exists( getcwd() . DIRECTORY_SEPARATOR . '.env' ) ) {
-			$dotenv = Dotenv::createImmutable( getcwd() );
-			$dotenv->load();
+		$path = getcwd();
+		if ( file_exists( $path . DIRECTORY_SEPARATOR . '.env' ) ) {
+			$this->loadDotenv( $path );
 		}
 	}
 
@@ -74,6 +74,34 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 	 */
 	public function uninstall( Composer $composer, IOInterface $io ) {
 		// no need to uninstall anything
+	}
+
+	/**
+	 * Activate vlucas/phpdotenv, if available.
+	 *
+	 * @param string $path
+	 */
+	protected function loadDotenv( $path ) {
+		// Dotenv V5
+		if ( method_exists( 'Dotenv\\Dotenv', 'createUnsafeImmutable' ) ) {
+			$dotenv = Dotenv::createUnsafeImmutable( $path );
+			$dotenv->safeLoad();
+			return;
+		}
+
+		// Dotenv V4
+		if ( method_exists( 'Dotenv\\Dotenv', 'createImmutable' ) ) {
+			$dotenv = Dotenv::createImmutable( $path );
+			$dotenv->safeLoad();
+			return;
+		}
+
+		// Dotenv V3
+		if ( method_exists( 'Dotenv\\Dotenv', 'create' ) ) {
+			$dotenv = Dotenv::create( $path );
+			$dotenv->safeLoad();
+			return;
+		}
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "composer-plugin",
   "license": "MIT",
   "require": {
-    "vlucas/phpdotenv": "^4.1.0",
+    "vlucas/phpdotenv": "^3.0 || ^4.0 || ^5.0",
     "composer-plugin-api": "^1.0 || ^2.0"
   },
   "authors": [


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [ ] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description

Adds support for Dotenv [v5](https://github.com/vlucas/phpdotenv/releases/tag/v5.0.0) while also keeping support for v4 and restoring support for v3.

This allows older projects that might be stuck on an older version of Dotenv to continue to benefit from updates to this Composer plugin.

## How has this been tested?

I'm testing this on a client project that uses Advanced Custom Fields Pro, Gravity Forms, and Polylang Pro.

## Types of changes

#### Added

- Method `Installer::loadDotenv()` to resolve and instantiate the currently available version of the `Dotenv` class.
- Class `AbstractPlugin` as basis for all supported WP plugins. The class provides a `get()` method which serves as a wrapper of `getenv()` that will throw an exception if the requested environment variable is missing.
- Class `MissingEnvException` in case an environment variable is missing.

#### Changed

- WP plugin classes to extend new `AbstractPlugin` and use its `get()` method instead of directly using `getenv()` function.