### PR TITLE
add wpae-acf-add-on support

### DIFF
--- a/plugins/WpAiPro.php
+++ b/plugins/WpAiPro.php
@@ -45,10 +45,19 @@ class WpAiPro {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		if ( 'wp-all-export-pro' === $this->slug ) {
+		if ( 'wp-all-export-pro' === $this->slug || 'wpae-acf-add-on' === $this->slug ) {
 			$license = getenv( 'WP_ALL_EXPORT_PRO_KEY' );
 			$url     = getenv( 'WP_ALL_EXPORT_PRO_URL' );
 			$name    = 'WP All Export';
+			switch ( $this->slug ) {
+				case 'wpae-acf-add-on':
+					$name    = 'ACF Export Add-On Pro';
+					$license = '';
+					break;
+				default:
+					$name = 'WP All Export';
+			}
+
 		} else {
 			$license = getenv( 'WP_ALL_IMPORT_PRO_KEY' );
 			$url     = getenv( 'WP_ALL_IMPORT_PRO_URL' );


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description
add wpae-acf-addon-pro support because its not include anymore into the main wpae pro plugin. (v1.7.0)
https://www.wpallimport.com/downloads/wp-all-export-pro/?changelog=1

## How has this been tested?
tested with our own license (elite bundle).

## Types of changes
adapt code to support new wpae acf pro addon
Should not break any current feature