### PR TITLE
Polylang: Fail if we download the incorrect version

### DIFF
--- a/plugins/PolylangPro.php
+++ b/plugins/PolylangPro.php
@@ -48,7 +48,7 @@ class PolylangPro {
 		/*
 		 * If the response is not the version we asked for then, bail
 		 */
-		if ( $this->version != $response['stable_version']) ) {
+		if ( $response['stable_version'] !== $this->version ) ) {
 			return '';
 		}
 

--- a/plugins/PolylangPro.php
+++ b/plugins/PolylangPro.php
@@ -44,6 +44,14 @@ class PolylangPro {
 			'url'        => getenv( 'POLYLANG_PRO_URL' ),
 			'version'    => $this->version,
 		) ), true );
+
+		/*
+		 * If the response is not the version we asked for then, bail
+		 */
+		if ( $this->version != $response['stable_version']) ) {
+			return '';
+		}
+
 		if ( ! empty( $response['download_link'] ) ) {
 			return $response['download_link'];
 		}


### PR DESCRIPTION
We are seeing the api give us the most recent version, but this version broke our website.

We spent a lot of time running down the fact that the version we requested was not being downloaded.

https://polylang.pro?edd_action=get_version&license=REDACTED&item_name=Polylang+Pro&url=REDACTED&version=3.1.4

returns

{
    "new_version": "3.2.3",
    "stable_version": "3.2.3",
    "name": "Polylang Pro",
    "slug": "polylang-pro",
    ...
}

It even says it is installing 3.1.4 during the composer install step.

I would have liked it to fail loudly when this occurs.
