### PR TITLE
fix: failed to execute unzip for all import/export

### DIFF
--- a/Http.php
+++ b/Http.php
@@ -28,7 +28,7 @@ class Http {
 		curl_setopt( $curl_handle, CURLOPT_SSL_VERIFYHOST, 0 );
 		curl_setopt( $curl_handle, CURLOPT_CUSTOMREQUEST, 'POST' );
 		if ( ! empty( $args ) ) {
-			curl_setopt( $curl_handle, CURLOPT_POSTFIELDS, http_build_query( $args ) );
+			curl_setopt( $curl_handle, CURLOPT_POSTFIELDS, http_build_query( $args, '', '&' ) );
 		}
 		$response = curl_exec( $curl_handle );
 		curl_close( $curl_handle );


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here [#27 ](https://github.com/junaidbhura/composer-wp-pro-plugins/issues/27).
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.

## Description
I changed api call in POST for GET the api return seems more stable.

## How has this been tested?
I have tested installation for  :
- wp-all-import-pro -> 4.7.6
- wpai-acf-add-on  -> 3.3.7
- wpai-linkcloak-add-on -> 1.1.5
- wpai-user-add-on -> 1.1.7
- wpai-woocommerce-add-on -> 3.3.3
- wp-all-export-pro -> 1.8.0
- wpae-acf-add-on -> 1.0.4
- wpae-woocommerce-add-on -> 1.0.5 
- wpae-user-add-on-pro -> 1.0.7
### testing environment
 - php 7.4.30
 - Composer 2.4.1

