### PR TITLE
Convert EDD plugins from POST to GET

### DIFF
--- a/Http.php
+++ b/Http.php
@@ -36,4 +36,27 @@ class Http {
 		return $response;
 	}
 
+	/**
+	 * GET request.
+	 *
+	 * @param string $url Base URL for requeset (without params)
+	 * @param array  $args Arguments to add to request
+	 * @return mixed
+	 */
+	public function get( $url = '', $args = array() ) {
+		$query_string = '';
+
+		$curl_handle = curl_init();
+		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, 1 );
+		curl_setopt( $curl_handle, CURLOPT_FOLLOWLOCATION, true );
+		if ( ! empty( $args ) ) {
+			$query_string = http_build_query( $args, '', '&' );
+		}
+		curl_setopt( $curl_handle, CURLOPT_URL, $url . '?' . $query_string );
+		$response = curl_exec( $curl_handle );
+		curl_close( $curl_handle );
+
+		return $response;
+	}
+
 }

--- a/plugins/PolylangPro.php
+++ b/plugins/PolylangPro.php
@@ -37,17 +37,20 @@ class PolylangPro {
 	 */
 	public function getDownloadUrl() {
 		$http     = new Http();
-		$response = json_decode( $http->post( 'https://polylang.pro', array(
+		$name = 'Polylang Pro';
+
+		$response = json_decode( $http->get( 'https://polylang.pro', array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'POLYLANG_PRO_KEY' ),
-			'item_name'  => 'Polylang Pro',
+			'item_name'  => $name,
 			'url'        => getenv( 'POLYLANG_PRO_URL' ),
 			'version'    => $this->version,
 		) ), true );
 		if ( ! empty( $response['download_link'] ) ) {
 			return $response['download_link'];
+		} else {
+			throw new Exception( 'Invalid download link for ' . $name );
 		}
-		return '';
 	}
 
 }

--- a/plugins/WpAiPro.php
+++ b/plugins/WpAiPro.php
@@ -7,6 +7,7 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use Exception;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
@@ -91,7 +92,7 @@ class WpAiPro {
 		}
 
 		$http     = new Http();
-		$response = json_decode( $http->post( 'https://www.wpallimport.com', array(
+		$response = json_decode( $http->get( 'https://www.wpallimport.com', array(
 			'edd_action' => 'get_version',
 			'license'    => $license,
 			'item_name'  => $name,
@@ -100,8 +101,9 @@ class WpAiPro {
 		) ), true );
 		if ( ! empty( $response['download_link'] ) ) {
 			return $response['download_link'];
+		} else {
+			throw new Exception( 'Invalid download link for ' . $name );
 		}
-		return '';
 	}
 
 }


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.

## Description
Updated EDD plugins, Polylang and WPAll Import, to use GET requests when calling the software licensing API to get the URL of the download. Fixes https://github.com/junaidbhura/composer-wp-pro-plugins/issues/27

## How has this been tested?
✅ Tested installing WP All Import with valid key
🚫 Polylang was not tested - I don't have a license.  Would be great to get that tested prior to merging. 

## Types of changes
* Bug fix