### PR TITLE
Add support for ACF Extended Pro

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -240,6 +240,10 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 		$package_name = $package->getName();
 
 		switch ( $package_name ) {
+			case 'junaidbhura/acf-extended-pro':
+				$plugin = new Plugins\AcfExtendedPro( $package->getPrettyVersion() );
+				break;
+
 			case 'junaidbhura/advanced-custom-fields-pro':
 				$plugin = new Plugins\AcfPro( $package->getPrettyVersion() );
 				break;

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Sensitive credentials (license keys, tokens) are read from environment variables
 ## Supported Plugins
 
 1. Advanced Custom Fields Pro
-2. Gravity Forms / Add-Ons
-3. Polylang Pro
-4. WP All Import / Export Pro / Add-Ons
+2. Advanced Custom Fields Extended Pro
+3. Gravity Forms / Add-Ons
+4. Polylang Pro
+5. WP All Import / Export Pro / Add-Ons
 
 ## Overview
 
@@ -35,6 +36,8 @@ Create a `.env` file in the root of your WordPress site, where the `composer.jso
 
 ```
 ACF_PRO_KEY="<acf_pro_license_key>"
+ACF_EXTENDED_PRO_KEY="<acf_extended_pro_license_key>"
+ACF_EXTENDED_PRO_URL="<registered_url_for_acf_extended_pro>"
 GRAVITY_FORMS_KEY="<gravity_forms_license_key>"
 POLYLANG_PRO_KEY="<polylang_pro_license_key>"
 POLYLANG_PRO_URL="<registered_url_for_polylang_pro>"
@@ -48,6 +51,21 @@ Add the following to your composer.json file:
 
 ```json
 "repositories": [
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/acf-extended-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://www.acf-extended.com/"
+      },
+      "require": {
+          "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
   {
     "type": "package",
     "package": {
@@ -185,6 +203,7 @@ Add the following to your composer.json file:
   },
 ],
 "require": {
+  "junaidbhura/acf-extended-pro": "*",
   "junaidbhura/advanced-custom-fields-pro": "*",
   "junaidbhura/gravityforms": "*",
   "junaidbhura/gravityformspolls": "*",

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Create a `.env` file in the root of your WordPress site, where the `composer.jso
 
 ```
 ACF_PRO_KEY="<acf_pro_license_key>"
-ACF_EXTENDED_PRO_KEY="<acf_extended_pro_license_key>"
-ACF_EXTENDED_PRO_URL="<registered_url_for_acf_extended_pro>"
+ACFE_PRO_KEY="<acf_extended_pro_license_key>"
+ACFE_PRO_URL="<registered_url_for_acf_extended_pro>"
 GRAVITY_FORMS_KEY="<gravity_forms_license_key>"
 POLYLANG_PRO_KEY="<polylang_pro_license_key>"
 POLYLANG_PRO_URL="<registered_url_for_polylang_pro>"

--- a/plugins/AcfExtendedPro.php
+++ b/plugins/AcfExtendedPro.php
@@ -7,6 +7,7 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
@@ -44,10 +45,20 @@ class AcfExtendedPro {
 			'url'        => getenv( 'ACFE_PRO_URL' ),
 			'version'    => $this->version,
 		) ), true );
-		if ( ! empty( $response['download_link'] ) ) {
-			return $response['download_link'];
+
+		if ( empty( $response['download_link'] ) ) {
+			return '';
 		}
-		return '';
+
+		if ( empty( $response['new_version'] ) ) {
+			return '';
+		}
+
+		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
+			return '';
+		}
+
+		return $response['download_link'];
 	}
 
 }

--- a/plugins/AcfExtendedPro.php
+++ b/plugins/AcfExtendedPro.php
@@ -39,9 +39,9 @@ class AcfExtendedPro {
 		$http     = new Http();
 		$response = json_decode( $http->post( 'https://acf-extended.com', array(
 			'edd_action' => 'get_version',
-			'license'    => getenv( 'ACF_EXTENDED_PRO_KEY' ),
+			'license'    => getenv( 'ACFE_PRO_KEY' ),
 			'item_name'  => 'ACF Extended Pro',
-			'url'        => getenv( 'ACF_EXTENDED_PRO_URL' ),
+			'url'        => getenv( 'ACFE_PRO_URL' ),
 			'version'    => $this->version,
 		) ), true );
 		if ( ! empty( $response['download_link'] ) ) {

--- a/plugins/AcfExtendedPro.php
+++ b/plugins/AcfExtendedPro.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ACF Extended Pro Plugin.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+use Junaidbhura\Composer\WPProPlugins\Http;
+
+/**
+ * AcfExtendedPro class.
+ */
+class AcfExtendedPro {
+
+	/**
+	 * The version number of the plugin to download.
+	 *
+	 * @var string Version number.
+	 */
+	protected $version = '';
+
+	/**
+	 * AcfExtendedPro constructor.
+	 *
+	 * @param string $version
+	 */
+	public function __construct( $version = '' ) {
+		$this->version = $version;
+	}
+
+	/**
+	 * Get the download URL for this plugin.
+	 *
+	 * @return string
+	 */
+	public function getDownloadUrl() {
+		$http     = new Http();
+		$response = json_decode( $http->post( 'https://acf-extended.com', array(
+			'edd_action' => 'get_version',
+			'license'    => getenv( 'ACF_EXTENDED_PRO_KEY' ),
+			'item_name'  => 'ACF Extended Pro',
+			'url'        => getenv( 'ACF_EXTENDED_PRO_URL' ),
+			'version'    => $this->version,
+		) ), true );
+		if ( ! empty( $response['download_link'] ) ) {
+			return $response['download_link'];
+		}
+		return '';
+	}
+
+}


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] An issue exists: [acf-extended/ACF-Extended#94](https://github.com/acf-extended/ACF-Extended/issues/94)
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description

Adds support for [ACF Extended Pro](https://www.acf-extended.com/pro) which uses Easy Digital Downloads.

## How has this been tested?

I'm testing this on a client project that uses Advanced Custom Fields Pro, ACF Extended Pro, and WPML.

## Types of changes

* Added class `AcfExtendedPro`, based on `PolylangPro`, for fetching its EDD download URL.
* Added package `junaidbhura/acf-extended-pro` to `Installer::getDownloadUrl()`.
* Added references to the `README.md`.
