### PR TITLE
Add support for PublishPress Pro

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -256,6 +256,8 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 			default:
 				if ( 0 === strpos( $package_name, 'junaidbhura/gravityforms' ) ) {
 					$plugin = new Plugins\GravityForms( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+				} elseif ( 0 === strpos( $package_name, 'junaidbhura/publishpress-' ) ) {
+					$plugin = new Plugins\PublishPressPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpai-' ) || 0 === strpos( $package_name, 'junaidbhura/wpae-' ) ) {
 					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
 				}

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ ACF_PRO_KEY="<acf_pro_license_key>"
 GRAVITY_FORMS_KEY="<gravity_forms_license_key>"
 POLYLANG_PRO_KEY="<polylang_pro_license_key>"
 POLYLANG_PRO_URL="<registered_url_for_polylang_pro>"
-PUBLISHPRESS_PRO_KEY="<publishpress_pro_license_key>"
-PUBLISHPRESS_PRO_URL="<registered_url_for_publishpress_pro>"
+PUBLISHPRESS_PRO_KEY="<publishpress_pro_membership_license_key>"
+PUBLISHPRESS_PRO_URL="<registered_url_for_publishpress_pro_membership>"
+PUBLISHPRESS_<plugin_slug>_PRO_KEY="<publishpress_pro_license_key>"
+PUBLISHPRESS_<plugin_slug>_PRO_URL="<registered_url_for_publishpress_pro>"
 WP_ALL_IMPORT_PRO_KEY="<wp_all_import_license_key>"
 WP_ALL_IMPORT_PRO_URL="<registered_url_for_wpai_pro>"
 WP_ALL_EXPORT_PRO_KEY="<wp_all_export_license_key>"
@@ -114,112 +116,7 @@ Add the following to your composer.json file:
   {
     "type": "package",
     "package": {
-      "name": "junaidbhura/publishpress-authors-pro",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://publishpress.com/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/publishpress-blocks-pro",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://publishpress.com/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/publishpress-capabilities-pro",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://publishpress.com/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/publishpress-checklists-pro",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://publishpress.com/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/publishpress-permissions-pro",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://publishpress.com/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
       "name": "junaidbhura/publishpress-planner-pro",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://publishpress.com/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/publishpress-revisions-pro",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://publishpress.com/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/publishpress-series-pro",
       "version": "<version_number>",
       "type": "wordpress-plugin",
       "dist": {
@@ -312,14 +209,7 @@ Add the following to your composer.json file:
   "junaidbhura/gravityforms": "*",
   "junaidbhura/gravityformspolls": "*",
   "junaidbhura/polylang-pro": "*",
-  "junaidbhura/publishpress-authors-pro": "*",
-  "junaidbhura/publishpress-blocks-pro": "*",
-  "junaidbhura/publishpress-capabilities-pro": "*",
-  "junaidbhura/publishpress-checklists-pro": "*",
-  "junaidbhura/publishpress-permissions-pro": "*",
   "junaidbhura/publishpress-planner-pro": "*",
-  "junaidbhura/publishpress-revisions-pro": "*",
-  "junaidbhura/publishpress-series-pro": "*",
   "junaidbhura/wp-all-import-pro": "*",
   "junaidbhura/wp-all-export-pro": "*",
   "junaidbhura/wpai-acf-add-on": "*",
@@ -342,16 +232,22 @@ Here's a list of all Gravity Forms add-on slugs: [https://docs.gravityforms.com/
 
 ### PublishPress Pro Plugins
 
-The following PublishPress Pro plugins are supported:
+You can use any PublishPress Pro plugins by simply adding it's slug like so:
 
-* `junaidbhura/publishpress-authors-pro`
-* `junaidbhura/publishpress-blocks-pro`
-* `junaidbhura/publishpress-capabilities-pro`
-* `junaidbhura/publishpress-checklists-pro`
-* `junaidbhura/publishpress-permissions-pro`
-* `junaidbhura/publishpress-planner-pro`
-* `junaidbhura/publishpress-revisions-pro`
-* `junaidbhura/publishpress-series-pro`
+`junaidbhura/<plugin-slug>`
+
+The following plugins are supported:
+
+| Package name                                | Environment variables                        |
+|:------------------------------------------- |:-------------------------------------------- |
+| `junaidbhura/publishpress-authors-pro`      | `PUBLISHPRESS_AUTHORS_PRO_<key_or_url>`      |
+| `junaidbhura/publishpress-blocks-pro`       | `PUBLISHPRESS_BLOCKS_PRO_<key_or_url>`       |
+| `junaidbhura/publishpress-capabilities-pro` | `PUBLISHPRESS_CAPABILITIES_PRO_<key_or_url>` |
+| `junaidbhura/publishpress-checklists-pro`   | `PUBLISHPRESS_CHECKLISTS_PRO_<key_or_url>`   |
+| `junaidbhura/publishpress-permissions-pro`  | `PUBLISHPRESS_PERMISSIONS_PRO_<key_or_url>`  |
+| `junaidbhura/publishpress-planner-pro`      | `PUBLISHPRESS_PLANNER_PRO_<key_or_url>`      |
+| `junaidbhura/publishpress-revisions-pro`    | `PUBLISHPRESS_REVISIONS_PRO_<key_or_url>`    |
+| `junaidbhura/publishpress-series-pro`       | `PUBLISHPRESS_SERIES_PRO_<key_or_url>`       |
 
 ### WP All Import Pro Add-Ons
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Sensitive credentials (license keys, tokens) are read from environment variables
 1. Advanced Custom Fields Pro
 2. Gravity Forms / Add-Ons
 3. Polylang Pro
-4. WP All Import / Export Pro / Add-Ons
+4. PublishPress Pro
+5. WP All Import / Export Pro / Add-Ons
 
 ## Overview
 
@@ -38,6 +39,8 @@ ACF_PRO_KEY="<acf_pro_license_key>"
 GRAVITY_FORMS_KEY="<gravity_forms_license_key>"
 POLYLANG_PRO_KEY="<polylang_pro_license_key>"
 POLYLANG_PRO_URL="<registered_url_for_polylang_pro>"
+PUBLISHPRESS_PRO_KEY="<publishpress_pro_license_key>"
+PUBLISHPRESS_PRO_URL="<registered_url_for_publishpress_pro>"
 WP_ALL_IMPORT_PRO_KEY="<wp_all_import_license_key>"
 WP_ALL_IMPORT_PRO_URL="<registered_url_for_wpai_pro>"
 WP_ALL_EXPORT_PRO_KEY="<wp_all_export_license_key>"
@@ -102,6 +105,126 @@ Add the following to your composer.json file:
       "dist": {
         "type": "zip",
         "url": "https://www.polylang.pro/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-authors-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-blocks-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-capabilities-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-checklists-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-permissions-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-planner-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-revisions-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/publishpress-series-pro",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://publishpress.com/"
       },
       "require": {
         "junaidbhura/composer-wp-pro-plugins": "*"
@@ -189,6 +312,14 @@ Add the following to your composer.json file:
   "junaidbhura/gravityforms": "*",
   "junaidbhura/gravityformspolls": "*",
   "junaidbhura/polylang-pro": "*",
+  "junaidbhura/publishpress-authors-pro": "*",
+  "junaidbhura/publishpress-blocks-pro": "*",
+  "junaidbhura/publishpress-capabilities-pro": "*",
+  "junaidbhura/publishpress-checklists-pro": "*",
+  "junaidbhura/publishpress-permissions-pro": "*",
+  "junaidbhura/publishpress-planner-pro": "*",
+  "junaidbhura/publishpress-revisions-pro": "*",
+  "junaidbhura/publishpress-series-pro": "*",
   "junaidbhura/wp-all-import-pro": "*",
   "junaidbhura/wp-all-export-pro": "*",
   "junaidbhura/wpai-acf-add-on": "*",
@@ -208,6 +339,19 @@ For example:
 `junaidbhura/gravityformspolls`
 
 Here's a list of all Gravity Forms add-on slugs: [https://docs.gravityforms.com/gravity-forms-add-on-slugs/](https://docs.gravityforms.com/gravity-forms-add-on-slugs/)
+
+### PublishPress Pro Plugins
+
+The following PublishPress Pro plugins are supported:
+
+* `junaidbhura/publishpress-authors-pro`
+* `junaidbhura/publishpress-blocks-pro`
+* `junaidbhura/publishpress-capabilities-pro`
+* `junaidbhura/publishpress-checklists-pro`
+* `junaidbhura/publishpress-permissions-pro`
+* `junaidbhura/publishpress-planner-pro`
+* `junaidbhura/publishpress-revisions-pro`
+* `junaidbhura/publishpress-series-pro`
 
 ### WP All Import Pro Add-Ons
 

--- a/plugins/PublishPressPro.php
+++ b/plugins/PublishPressPro.php
@@ -7,6 +7,7 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
@@ -118,19 +119,19 @@ class PublishPressPro {
 			'version'    => $this->version,
 		) ), true );
 
-		/**
-		 * If the response does not have a version number or the version number
-		 * does not match the package constraint, bail.
-		 */
-		if ( empty( $response['new_version'] ) || $response['new_version'] !== $this->version ) {
+		if ( empty( $response['download_link'] ) ) {
 			return '';
 		}
 
-		if ( ! empty( $response['download_link'] ) ) {
-			return $response['download_link'];
+		if ( empty( $response['new_version'] ) ) {
+			return '';
 		}
 
-		return '';
+		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
+			return '';
+		}
+
+		return $response['download_link'];
 	}
 
 }

--- a/plugins/PublishPressPro.php
+++ b/plugins/PublishPressPro.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * PublishPress Pro Plugin.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+use Junaidbhura\Composer\WPProPlugins\Http;
+
+/**
+ * PublishPressPro class.
+ */
+class PublishPressPro {
+
+	/**
+	 * The version number of the plugin to download.
+	 *
+	 * @var string Version number.
+	 */
+	protected $version = '';
+
+	/**
+	 * The slug of which plugin to download.
+	 *
+	 * @var string Plugin slug.
+	 */
+	protected $slug = '';
+
+	/**
+	 * WpAiPro constructor.
+	 *
+	 * @param string $version
+	 * @param string $slug
+	 */
+	public function __construct( $version = '', $slug = 'publishpress-planner-pro' ) {
+		$this->version = $version;
+		$this->slug    = $slug;
+	}
+
+	/**
+	 * Get the download URL for this plugin.
+	 *
+	 * @return string
+	 */
+	public function getDownloadUrl() {
+		$packages = array(
+			'publishpress-authors-pro'      => 7203,
+			'publishpress-blocks-pro'       => 98972,
+			'publishpress-capabilities-pro' => 44811,
+			'publishpress-checklists-pro'   => 6465,
+			'publishpress-permissions-pro'  => 34506,
+			'publishpress-planner-pro'      => 49742,
+			'publishpress-revisions-pro'    => 40280,
+			'publishpress-series-pro'       => 110550,
+		);
+
+		if ( array_key_exists( $this->slug, $packages ) ) {
+			$http     = new Http();
+			$response = json_decode( $http->get( 'https://publishpress.com', array(
+				'edd_action' => 'get_version',
+				'license'    => getenv( 'PUBLISHPRESS_PRO_KEY' ),
+				'item_id'    => $packages[ $this->slug ],
+				'url'        => getenv( 'PUBLISHPRESS_PRO_URL' ),
+				'version'    => $this->version,
+			) ), true );
+
+			if ( ! empty( $response['download_link'] ) ) {
+				return $response['download_link'];
+			}
+		}
+
+		return '';
+	}
+
+}


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] An issue does not exists
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description

Adds support for [PublishPress Pro](https://publishpress.com/) plugins which uses Easy Digital Downloads.

## How has this been tested?

I'm testing this on a client project that uses Advanced Custom Fields Pro, ACF Extended Pro, and WPML.

## Types of changes

* Added class `PublishPressPro`, based on `WpAiPro`, for fetching its EDD download URL.
* Added package `junaidbhura/publishpress-*` to `Installer::getDownloadUrl()`.
* Added references to the `README.md`.
* Supported packages:
	* `junaidbhura/publishpress-authors-pro`
	* `junaidbhura/publishpress-blocks-pro`
	* `junaidbhura/publishpress-capabilities-pro`
	* `junaidbhura/publishpress-checklists-pro`
	* `junaidbhura/publishpress-permissions-pro`
	* `junaidbhura/publishpress-planner-pro`
	* `junaidbhura/publishpress-revisions-pro`
	* `junaidbhura/publishpress-series-pro`