### PR TITLE
Fail if we download the incorrect version of WPAI, WPAE, or Polylang

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,9 @@
   "type": "composer-plugin",
   "license": "MIT",
   "require": {
-    "vlucas/phpdotenv": "^3.0 || ^4.0 || ^5.0",
-    "composer-plugin-api": "^1.0 || ^2.0"
+    "composer-plugin-api": "^1.0 || ^2.0",
+    "composer/semver": "^1.0 || ^2.0 || ^3.0",
+    "vlucas/phpdotenv": "^3.0 || ^4.0 || ^5.0"
   },
   "authors": [
     {

--- a/plugins/PolylangPro.php
+++ b/plugins/PolylangPro.php
@@ -44,6 +44,14 @@ class PolylangPro {
 			'url'        => getenv( 'POLYLANG_PRO_URL' ),
 			'version'    => $this->version,
 		) ), true );
+
+		/*
+		 * If the response is not the version we asked for then, bail
+		 */
+		if ( $response['stable_version'] !== $this->version ) ) {
+			return '';
+		}
+
 		if ( ! empty( $response['download_link'] ) ) {
 			return $response['download_link'];
 		}

--- a/plugins/PolylangPro.php
+++ b/plugins/PolylangPro.php
@@ -7,6 +7,7 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
@@ -45,17 +46,19 @@ class PolylangPro {
 			'version'    => $this->version,
 		) ), true );
 
-		/*
-		 * If the response is not the version we asked for then, bail
-		 */
-		if ( $response['stable_version'] !== $this->version ) ) {
+		if ( empty( $response['download_link'] ) ) {
 			return '';
 		}
 
-		if ( ! empty( $response['download_link'] ) ) {
-			return $response['download_link'];
+		if ( empty( $response['new_version'] ) ) {
+			return '';
 		}
-		return '';
+
+		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
+			return '';
+		}
+
+		return $response['download_link'];
 	}
 
 }

--- a/plugins/WpAiPro.php
+++ b/plugins/WpAiPro.php
@@ -7,6 +7,7 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
@@ -98,11 +99,20 @@ class WpAiPro {
 			'url'        => $url,
 			'version'    => $this->version,
 		) ), true );
-		if ( ! empty( $response['download_link'] ) ) {
-			return $response['download_link'];
+
+		if ( empty( $response['download_link'] ) ) {
+			return '';
 		}
 
-		return '';
+		if ( empty( $response['new_version'] ) ) {
+			return '';
+		}
+
+		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
+			return '';
+		}
+
+		return $response['download_link'];
 	}
 
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] An issue does not exists
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description

Supersedes (and includes) PR #38 to include WP All Import / Export Pro and rebase changes since 1.4.0.

See comments [7](https://github.com/junaidbhura/composer-wp-pro-plugins/pull/38#pullrequestreview-1264095955) and [8](https://github.com/junaidbhura/composer-wp-pro-plugins/pull/38#issuecomment-1398823030) for context.

## How has this been tested?

I'm testing this on a client project that uses Advanced Custom Fields Pro, ACF Extended Pro, Ninja Forms, and PublishPress Pro.

## Types of changes

* Require [composer/semver](https://github.com/composer/semver) v1–3.
* Add version check to `PolylangPro` and `WpAiPro`.
	* First check if `download_link` has a value, then check if `new_version` has a value, then check if `new_version` matches package version.