### PR TITLE
Change gravityforms download URL as gravityhelp.com is now gone

### DIFF
--- a/plugins/GravityForms.php
+++ b/plugins/GravityForms.php
@@ -46,7 +46,7 @@ class GravityForms {
 	 */
 	public function getDownloadUrl() {
 		$http     = new Http();
-		$response = unserialize( $http->post( 'https://www.gravityhelp.com/wp-content/plugins/gravitymanager/api.php?op=get_plugin&slug=' . $this->slug . '&key=' . getenv( 'GRAVITY_FORMS_KEY' ) ) );
+		$response = unserialize( $http->post( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php?op=get_plugin&slug=' . $this->slug . '&key=' . getenv( 'GRAVITY_FORMS_KEY' ) ) );
 		if ( ! empty( $response['download_url_latest'] ) ) {
 			return str_replace( 'http://', 'https://', $response['download_url_latest'] );
 		}


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] I've created an issue and referenced it here.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code has proper inline documentation.

## Description
This relates to https://github.com/junaidbhura/composer-wp-pro-plugins/issues/49
The domain used by gravity forms (www.gravityhelp.com) is now gone, so the domain used by the gravityforms plugin has been updated to gravityapi.com.

## How has this been tested?
I have modified the method in my environment and successfully ran a `composer install`.
