### PR TITLE
Add support for PublishPress Future Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ The following plugins are supported:
 | `junaidbhura/publishpress-blocks-pro`       | `PUBLISHPRESS_BLOCKS_PRO_<key_or_url>`       |
 | `junaidbhura/publishpress-capabilities-pro` | `PUBLISHPRESS_CAPABILITIES_PRO_<key_or_url>` |
 | `junaidbhura/publishpress-checklists-pro`   | `PUBLISHPRESS_CHECKLISTS_PRO_<key_or_url>`   |
+| `junaidbhura/publishpress-future-pro`       | `PUBLISHPRESS_FUTURE_PRO_<key_or_url>`       |
 | `junaidbhura/publishpress-permissions-pro`  | `PUBLISHPRESS_PERMISSIONS_PRO_<key_or_url>`  |
 | `junaidbhura/publishpress-planner-pro`      | `PUBLISHPRESS_PLANNER_PRO_<key_or_url>`      |
 | `junaidbhura/publishpress-revisions-pro`    | `PUBLISHPRESS_REVISIONS_PRO_<key_or_url>`    |

--- a/plugins/PublishPressPro.php
+++ b/plugins/PublishPressPro.php
@@ -78,6 +78,11 @@ class PublishPressPro {
 				$env = 'CHECKLISTS';
 				break;
 
+			case 'publishpress-future-pro':
+				$id  = 129032;
+				$env = 'FUTURE';
+				break;
+
 			case 'publishpress-permissions-pro':
 				$id  = 34506;
 				$env = 'PERMISSIONS';


### PR DESCRIPTION
## Checklist:
- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] An issue does not exists; follow-up to PR #45.
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Description

Adds support for [PublishPress Future Pro](https://publishpress.com/blog/publishpress-future/future-pro-available/) plugin.

## How has this been tested?

I'm testing this on a client project that uses Advanced Custom Fields Pro, ACF Extended Pro, and WPML.

## Types of changes

* Added references to the `README.md`.
* Supported package:
  * `junaidbhura/publishpress-future-pro`
