### PR TITLE
Improve error handling and abstract download classes

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -238,34 +238,35 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 	protected function getDownloadUrl( PackageInterface $package ) {
 		$plugin       = null;
 		$package_name = $package->getName();
+		$plugin_name  = str_replace( 'junaidbhura/', '', $package_name );
 
 		switch ( $package_name ) {
 			case 'junaidbhura/acf-extended-pro':
-				$plugin = new Plugins\AcfExtendedPro( $package->getPrettyVersion() );
+				$plugin = new Plugins\AcfExtendedPro( $package->getPrettyVersion(), $plugin_name );
 				break;
 
 			case 'junaidbhura/advanced-custom-fields-pro':
-				$plugin = new Plugins\AcfPro( $package->getPrettyVersion() );
+				$plugin = new Plugins\AcfPro( $package->getPrettyVersion(), $plugin_name );
 				break;
 
 			case 'junaidbhura/polylang-pro':
-				$plugin = new Plugins\PolylangPro( $package->getPrettyVersion() );
+				$plugin = new Plugins\PolylangPro( $package->getPrettyVersion(), $plugin_name );
 				break;
 
 			case 'junaidbhura/wp-all-import-pro':
 			case 'junaidbhura/wp-all-export-pro':
-				$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+				$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), $plugin_name );
 				break;
 
 			default:
 				if ( 0 === strpos( $package_name, 'junaidbhura/gravityforms' ) ) {
-					$plugin = new Plugins\GravityForms( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\GravityForms( $package->getPrettyVersion(), $plugin_name );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/ninja-forms-' ) ) {
-					$plugin = new Plugins\NinjaForms( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\NinjaForms( $package->getPrettyVersion(), $plugin_name );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/publishpress-' ) ) {
-					$plugin = new Plugins\PublishPressPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\PublishPressPro( $package->getPrettyVersion(), $plugin_name );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpai-' ) || 0 === strpos( $package_name, 'junaidbhura/wpae-' ) ) {
-					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), str_replace( 'junaidbhura/', '', $package_name ) );
+					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), $plugin_name );
 				}
 		}
 

--- a/plugins/AbstractEddPlugin.php
+++ b/plugins/AbstractEddPlugin.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Composer\Semver\Semver;
+use UnexpectedValueException;
 
 /**
  * AbstractEddPlugin class.
@@ -21,16 +22,27 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 	 * @return string
 	 */
 	protected function extractDownloadUrl( array $response ) {
-		if ( empty( $response['download_link'] ) ) {
-			return '';
+		if ( empty( $response['download_link'] ) || ! is_string( $response['download_link'] ) ) {
+			throw new UnexpectedValueException(sprintf(
+				'Expected a valid download URL for package %s',
+				'junaidbhura/' . $this->slug
+			));
 		}
 
-		if ( empty( $response['new_version'] ) ) {
-			return '';
+		if ( empty( $response['new_version'] ) || ! is_scalar( $response['new_version'] ) ) {
+			throw new UnexpectedValueException(sprintf(
+				'Expected a valid download version number for package %s',
+				'junaidbhura/' . $this->slug
+			));
 		}
 
 		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
-			return '';
+			throw new UnexpectedValueException(sprintf(
+				'Expected download version (%s) to match installed version (%s) of package %s',
+				$response['new_version'],
+				$this->version,
+				'junaidbhura/' . $this->slug
+			));
 		}
 
 		return $response['download_link'];

--- a/plugins/AbstractEddPlugin.php
+++ b/plugins/AbstractEddPlugin.php
@@ -23,26 +23,26 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 	 */
 	protected function extractDownloadUrl( array $response ) {
 		if ( empty( $response['download_link'] ) || ! is_string( $response['download_link'] ) ) {
-			throw new UnexpectedValueException(sprintf(
+			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download URL for package %s',
 				'junaidbhura/' . $this->slug
-			));
+			) );
 		}
 
 		if ( empty( $response['new_version'] ) || ! is_scalar( $response['new_version'] ) ) {
-			throw new UnexpectedValueException(sprintf(
+			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download version number for package %s',
 				'junaidbhura/' . $this->slug
-			));
+			) );
 		}
 
 		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
-			throw new UnexpectedValueException(sprintf(
+			throw new UnexpectedValueException( sprintf(
 				'Expected download version (%s) to match installed version (%s) of package %s',
 				$response['new_version'],
 				$this->version,
 				'junaidbhura/' . $this->slug
-			));
+			) );
 		}
 
 		return $response['download_link'];

--- a/plugins/AbstractEddPlugin.php
+++ b/plugins/AbstractEddPlugin.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Abstract Easy Digital Downloads (EDD) Plugin.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+use Composer\Semver\Semver;
+
+/**
+ * AbstractEddPlugin class.
+ */
+abstract class AbstractEddPlugin extends AbstractPlugin {
+
+	/**
+	 * Get the download URL for this plugin.
+	 *
+	 * @param  array<string, mixed> $response The EDD API response.
+	 * @return string
+	 */
+	protected function extractDownloadUrl( array $response ) {
+		if ( empty( $response['download_link'] ) ) {
+			return '';
+		}
+
+		if ( empty( $response['new_version'] ) ) {
+			return '';
+		}
+
+		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
+			return '';
+		}
+
+		return $response['download_link'];
+	}
+
+}

--- a/plugins/AbstractPlugin.php
+++ b/plugins/AbstractPlugin.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Abstract Plugin.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+/**
+ * AbstractPlugin class.
+ */
+abstract class AbstractPlugin {
+
+	/**
+	 * The version number of the plugin to download.
+	 *
+	 * @var string Version number.
+	 */
+	protected $version = '';
+
+	/**
+	 * The slug of which plugin to download.
+	 *
+	 * @var string Plugin slug.
+	 */
+	protected $slug = '';
+
+	/**
+	 * AbstractPlugin constructor.
+	 *
+	 * @param string $version
+	 */
+	public function __construct( $version = '', $slug = '' ) {
+		$this->version = $version;
+		$this->slug    = $slug;
+	}
+
+	/**
+	 * Get the download URL for this plugin.
+	 *
+	 * @return string
+	 */
+	abstract public function getDownloadUrl();
+
+}

--- a/plugins/AcfExtendedPro.php
+++ b/plugins/AcfExtendedPro.php
@@ -7,29 +7,12 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
-use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
  * AcfExtendedPro class.
  */
-class AcfExtendedPro {
-
-	/**
-	 * The version number of the plugin to download.
-	 *
-	 * @var string Version number.
-	 */
-	protected $version = '';
-
-	/**
-	 * AcfExtendedPro constructor.
-	 *
-	 * @param string $version
-	 */
-	public function __construct( $version = '' ) {
-		$this->version = $version;
-	}
+class AcfExtendedPro extends AbstractEddPlugin {
 
 	/**
 	 * Get the download URL for this plugin.
@@ -46,19 +29,7 @@ class AcfExtendedPro {
 			'version'    => $this->version,
 		) ), true );
 
-		if ( empty( $response['download_link'] ) ) {
-			return '';
-		}
-
-		if ( empty( $response['new_version'] ) ) {
-			return '';
-		}
-
-		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
-			return '';
-		}
-
-		return $response['download_link'];
+		return $this->extractDownloadUrl( $response );
 	}
 
 }

--- a/plugins/AcfPro.php
+++ b/plugins/AcfPro.php
@@ -10,23 +10,7 @@ namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 /**
  * AcfPro class.
  */
-class AcfPro {
-
-	/**
-	 * The version number of the plugin to download.
-	 *
-	 * @var string Version number.
-	 */
-	protected $version = '';
-
-	/**
-	 * AcfPro constructor.
-	 *
-	 * @param string $version
-	 */
-	public function __construct( $version = '' ) {
-		$this->version = $version;
-	}
+class AcfPro extends AbstractPlugin {
 
 	/**
 	 * Get the download URL for this plugin.

--- a/plugins/GravityForms.php
+++ b/plugins/GravityForms.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use UnexpectedValueException;
 
 /**
  * GravityForms class.
@@ -32,10 +33,15 @@ class GravityForms extends AbstractPlugin {
 	public function getDownloadUrl() {
 		$http     = new Http();
 		$response = unserialize( $http->post( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php?op=get_plugin&slug=' . $this->slug . '&key=' . getenv( 'GRAVITY_FORMS_KEY' ) ) );
-		if ( ! empty( $response['download_url_latest'] ) ) {
-			return str_replace( 'http://', 'https://', $response['download_url_latest'] );
+
+		if ( empty( $response['download_url_latest'] ) || ! is_string( $response['download_url_latest'] ) ) {
+			throw new UnexpectedValueException(sprintf(
+				'Expected a valid download URL for package %s',
+				'junaidbhura/' . $this->slug
+			));
 		}
-		return '';
+
+		return str_replace( 'http://', 'https://', $response['download_url_latest'] );
 	}
 
 }

--- a/plugins/GravityForms.php
+++ b/plugins/GravityForms.php
@@ -12,21 +12,7 @@ use Junaidbhura\Composer\WPProPlugins\Http;
 /**
  * GravityForms class.
  */
-class GravityForms {
-
-	/**
-	 * The version number of the plugin to download.
-	 *
-	 * @var string Version number.
-	 */
-	protected $version = '';
-
-	/**
-	 * The slug of which Gravity Forms plugin to download.
-	 *
-	 * @var string Plugin slug.
-	 */
-	protected $slug = '';
+class GravityForms extends AbstractPlugin {
 
 	/**
 	 * GravityForms constructor.
@@ -35,8 +21,7 @@ class GravityForms {
 	 * @param string $slug
 	 */
 	public function __construct( $version = '', $slug = 'gravityforms' ) {
-		$this->version = $version;
-		$this->slug    = $slug;
+		parent::__construct( $version, $slug );
 	}
 
 	/**

--- a/plugins/GravityForms.php
+++ b/plugins/GravityForms.php
@@ -35,10 +35,10 @@ class GravityForms extends AbstractPlugin {
 		$response = unserialize( $http->post( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php?op=get_plugin&slug=' . $this->slug . '&key=' . getenv( 'GRAVITY_FORMS_KEY' ) ) );
 
 		if ( empty( $response['download_url_latest'] ) || ! is_string( $response['download_url_latest'] ) ) {
-			throw new UnexpectedValueException(sprintf(
+			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download URL for package %s',
 				'junaidbhura/' . $this->slug
-			));
+			) );
 		}
 
 		return str_replace( 'http://', 'https://', $response['download_url_latest'] );

--- a/plugins/NinjaForms.php
+++ b/plugins/NinjaForms.php
@@ -7,38 +7,12 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
-use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
  * NinjaForms class.
  */
-class NinjaForms {
-
-	/**
-	 * The version number of the plugin to download.
-	 *
-	 * @var string Version number.
-	 */
-	protected $version = '';
-
-	/**
-	 * The slug of which plugin to download.
-	 *
-	 * @var string Plugin slug.
-	 */
-	protected $slug = '';
-
-	/**
-	 * WpAiPro constructor.
-	 *
-	 * @param string $version
-	 * @param string $slug
-	 */
-	public function __construct( $version = '', $slug = '' ) {
-		$this->version = $version;
-		$this->slug    = $slug;
-	}
+class NinjaForms extends AbstractEddPlugin {
 
 	/**
 	 * Get the download URL for this plugin.
@@ -341,19 +315,7 @@ class NinjaForms {
 			'version'    => $this->version,
 		) ), true );
 
-		if ( empty( $response['download_link'] ) ) {
-			return '';
-		}
-
-		if ( empty( $response['new_version'] ) ) {
-			return '';
-		}
-
-		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
-			return '';
-		}
-
-		return $response['download_link'];
+		return $this->extractDownloadUrl( $response );
 	}
 
 }

--- a/plugins/NinjaForms.php
+++ b/plugins/NinjaForms.php
@@ -296,10 +296,10 @@ class NinjaForms extends AbstractEddPlugin {
 				break;
 
 			default:
-				throw new UnexpectedValueException(sprintf(
+				throw new UnexpectedValueException( sprintf(
 					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
 					'junaidbhura/' . $this->slug
-				));
+				) );
 		}
 
 		if ( $env ) {

--- a/plugins/NinjaForms.php
+++ b/plugins/NinjaForms.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use UnexpectedValueException;
 
 /**
  * NinjaForms class.
@@ -295,7 +296,10 @@ class NinjaForms extends AbstractEddPlugin {
 				break;
 
 			default:
-				return '';
+				throw new UnexpectedValueException(sprintf(
+					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
+					'junaidbhura/' . $this->slug
+				));
 		}
 
 		if ( $env ) {

--- a/plugins/PolylangPro.php
+++ b/plugins/PolylangPro.php
@@ -7,29 +7,12 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
-use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
  * PolylangPro class.
  */
-class PolylangPro {
-
-	/**
-	 * The version number of the plugin to download.
-	 *
-	 * @var string Version number.
-	 */
-	protected $version = '';
-
-	/**
-	 * PolylangPro constructor.
-	 *
-	 * @param string $version
-	 */
-	public function __construct( $version = '' ) {
-		$this->version = $version;
-	}
+class PolylangPro extends AbstractEddPlugin {
 
 	/**
 	 * Get the download URL for this plugin.
@@ -46,19 +29,7 @@ class PolylangPro {
 			'version'    => $this->version,
 		) ), true );
 
-		if ( empty( $response['download_link'] ) ) {
-			return '';
-		}
-
-		if ( empty( $response['new_version'] ) ) {
-			return '';
-		}
-
-		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
-			return '';
-		}
-
-		return $response['download_link'];
+		return $this->extractDownloadUrl( $response );
 	}
 
 }

--- a/plugins/PublishPressPro.php
+++ b/plugins/PublishPressPro.php
@@ -84,10 +84,10 @@ class PublishPressPro extends AbstractEddPlugin {
 				break;
 
 			default:
-				throw new UnexpectedValueException(sprintf(
+				throw new UnexpectedValueException( sprintf(
 					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
 					'junaidbhura/' . $this->slug
-				));
+				) );
 		}
 
 		if ( $env ) {

--- a/plugins/PublishPressPro.php
+++ b/plugins/PublishPressPro.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use UnexpectedValueException;
 
 /**
  * PublishPressPro class.
@@ -83,7 +84,10 @@ class PublishPressPro extends AbstractEddPlugin {
 				break;
 
 			default:
-				return '';
+				throw new UnexpectedValueException(sprintf(
+					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
+					'junaidbhura/' . $this->slug
+				));
 		}
 
 		if ( $env ) {

--- a/plugins/PublishPressPro.php
+++ b/plugins/PublishPressPro.php
@@ -7,27 +7,12 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
-use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
  * PublishPressPro class.
  */
-class PublishPressPro {
-
-	/**
-	 * The version number of the plugin to download.
-	 *
-	 * @var string Version number.
-	 */
-	protected $version = '';
-
-	/**
-	 * The slug of which plugin to download.
-	 *
-	 * @var string Plugin slug.
-	 */
-	protected $slug = '';
+class PublishPressPro extends AbstractEddPlugin {
 
 	/**
 	 * WpAiPro constructor.
@@ -36,8 +21,7 @@ class PublishPressPro {
 	 * @param string $slug
 	 */
 	public function __construct( $version = '', $slug = 'publishpress-planner-pro' ) {
-		$this->version = $version;
-		$this->slug    = $slug;
+		parent::__construct( $version, $slug );
 	}
 
 	/**
@@ -119,19 +103,7 @@ class PublishPressPro {
 			'version'    => $this->version,
 		) ), true );
 
-		if ( empty( $response['download_link'] ) ) {
-			return '';
-		}
-
-		if ( empty( $response['new_version'] ) ) {
-			return '';
-		}
-
-		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
-			return '';
-		}
-
-		return $response['download_link'];
+		return $this->extractDownloadUrl( $response );
 	}
 
 }

--- a/plugins/WpAiPro.php
+++ b/plugins/WpAiPro.php
@@ -7,27 +7,12 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
-use Composer\Semver\Semver;
 use Junaidbhura\Composer\WPProPlugins\Http;
 
 /**
  * WpAiPro class.
  */
-class WpAiPro {
-
-	/**
-	 * The version number of the plugin to download.
-	 *
-	 * @var string Version number.
-	 */
-	protected $version = '';
-
-	/**
-	 * The slug of which plugin to download.
-	 *
-	 * @var string Plugin slug.
-	 */
-	protected $slug = '';
+class WpAiPro extends AbstractEddPlugin {
 
 	/**
 	 * WpAiPro constructor.
@@ -36,8 +21,7 @@ class WpAiPro {
 	 * @param string $slug
 	 */
 	public function __construct( $version = '', $slug = 'wp-all-import-pro' ) {
-		$this->version = $version;
-		$this->slug    = $slug;
+		parent::__construct( $version, $slug );
 	}
 
 	/**
@@ -100,19 +84,7 @@ class WpAiPro {
 			'version'    => $this->version,
 		) ), true );
 
-		if ( empty( $response['download_link'] ) ) {
-			return '';
-		}
-
-		if ( empty( $response['new_version'] ) ) {
-			return '';
-		}
-
-		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
-			return '';
-		}
-
-		return $response['download_link'];
+		return $this->extractDownloadUrl( $response );
 	}
 
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] Issues: #1, #14, #18, #27, #33, #41
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Issue

When an add-on is unsupported or if a download URL can not be retrieved or resolved, an empty string is returned.

This has the unintended consequence of causing Composer to fail much later during the package installation routine resulting in the following error:

#### Example of the error "Failed to extract junaidbhura/ninja-forms-foobar"

```shell
$ composer require junaidbhura/ninja-forms-foobar
./composer.json has been updated
Running composer update junaidbhura/ninja-forms-foobar
Gathering patches from patch file.
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading junaidbhura/ninja-forms-foobar (1.0.0)
Gathering patches from patch file.
Gathering patches for dependencies. This might take a minute.
  - Installing junaidbhura/ninja-forms-foobar (1.0.0): Extracting archive
    Failed to extract junaidbhura/ninja-forms-foobar: (9) '/usr/bin/unzip' -qq '…/vendor/composer/tmp-3e5657bb7bb690e28af71c04f2d6fece' -d '…/vendor/composer/a78af123'

[…/vendor/composer/tmp-3e5657bb7bb690e28af71c04f2d6fece]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of …/vendor/composer/tmp-3e5657bb7bb690e28af71c04f2d6fece or
        …/vendor/composer/tmp-3e5657bb7bb690e28af71c04f2d6fece.zip, and cannot find …/vendor/composer/tmp-3e5657bb7bb690e28af71c04f2d6fece.ZIP, period.

    The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems)
    Unzip with unzip command failed, falling back to ZipArchive class
    Install of junaidbhura/ninja-forms-foobar failed

In ZipDownloader.php line 220:

  '…/vendor/composer/tmp-3e5657bb7bb690e28af71c04f2d6fece' is not a zip archive.
```

To summarize this lengthy error: Composer is attempting to unzip a blank file downloaded from the empty string.

This error has confused many, including myself, as to the real cause. There are numerous issues about it.

## Solution

The solution to this is to explicitly throw an exception during the processing of an add-on and the processing of the download URL to abort the package installation process sooner and provide a clear reason for what went wrong.

To simplify the addition of these error messages, I've abstracted common properties and methods into two base classes for greater consistency between plugin downloaders, especially EDD-distributed plugins.

I've chosen [`UnexpectedValueException`](https://www.php.net/class.UnexpectedValueException) since it seems like a good fit for most scenarios based on similar usage in Composer.

There are currently four kinds of error messages thrown:

1. Package is not supported (Ninja Forms and PublishPress Pro)
2. Download URL is invalid/missing (EDD and Gravity Forms)
3. Download version is invalid/missing (EDD only)
4. Download version and installed version do not match (EDD only)

#### Example of the error "Could not find a matching package" (1)

```shell
$ composer require junaidbhura/ninja-forms-foobar
Info from https://repo.packagist.org: #StandWithUkraine
./composer.json has been updated
Running composer update junaidbhura/ninja-forms-foobar
Gathering patches from patch file.
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking junaidbhura/ninja-forms-foobar (1.0.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals

In NinjaForms.php line 299:

  Could not find a matching package for junaidbhura/ninja-forms-foobar. Check the package spelling and that the package is supported
```

#### Example of the error "Expected a valid download URL" (2)

```shell
$ composer require junaidbhura/ninja-forms-foobar
./composer.json has been updated
Running composer update junaidbhura/ninja-forms-foobar
Gathering patches from patch file.
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals

In AbstractEddPlugin.php line 26:

  Expected a valid download URL for package junaidbhura/ninja-forms-foobar
```

#### Example of the error "Expected a valid download version number" (3)

```shell
$ composer require junaidbhura/ninja-forms-foobar
./composer.json has been updated
Running composer update junaidbhura/ninja-forms-foobar
Gathering patches from patch file.
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals

In AbstractEddPlugin.php line 33:

  Expected a valid download version number for package junaidbhura/ninja-forms-foobar
```

#### Example of the error "Expected download version to match installed version" (4)

```shell
$ composer require junaidbhura/ninja-forms-foobar
./composer.json has been updated
Running composer update junaidbhura/ninja-forms-foobar
Gathering patches from patch file.
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals

In AbstractEddPlugin.php line 40:

  Expected download version (3.0.0) to match installed version (2.0.0) of package junaidbhura/ninja-forms-foobar
```

## How has this been tested?

I'm testing this on a client project that uses Advanced Custom Fields Pro, ACF Extended Pro, and WPML.

## Screenshots

![Screen capture of the error "Failed to extract junaidbhura/ninja-forms-foobar"](https://user-images.githubusercontent.com/29353/223218379-31b9c3ad-2596-4502-a6a7-cb722ba74e3a.png)

![Screen capture of the error "Could not find a matching package"](https://user-images.githubusercontent.com/29353/223220361-f11b7da4-b1a8-43b7-b592-698c45f68535.png)

![Screen capture of the error "Expected a valid download URL"](https://user-images.githubusercontent.com/29353/223220686-b3f46ab6-bbb8-491d-96b9-24d9b19a9567.png)

![Screen capture of the error "Expected a valid download version number"](https://user-images.githubusercontent.com/29353/223222071-a15b63b5-19de-4c33-94f2-ffbabe1615fc.png)

![Screen capture of the error "Expected download version to match installed version"](https://user-images.githubusercontent.com/29353/223222087-cabc82e9-b4cf-4b95-aef2-d5de84863291.png)
