### PR TITLE
Add support for WPML (plugin / add-ons)

### DIFF
--- a/Installer.php
+++ b/Installer.php
@@ -268,7 +268,7 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpai-' ) || 0 === strpos( $package_name, 'junaidbhura/wpae-' ) ) {
 					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), $plugin_name );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpml-' ) ) {
-					$plugin = new Plugins\WPML( $package->getPrettyVersion(), $plugin_name );
+					$plugin = new Plugins\Wpml( $package->getPrettyVersion(), $plugin_name );
 				}
 		}
 

--- a/Installer.php
+++ b/Installer.php
@@ -267,6 +267,8 @@ class Installer implements PluginInterface, EventSubscriberInterface {
 					$plugin = new Plugins\PublishPressPro( $package->getPrettyVersion(), $plugin_name );
 				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpai-' ) || 0 === strpos( $package_name, 'junaidbhura/wpae-' ) ) {
 					$plugin = new Plugins\WpAiPro( $package->getPrettyVersion(), $plugin_name );
+				} elseif ( 0 === strpos( $package_name, 'junaidbhura/wpml-' ) ) {
+					$plugin = new Plugins\WPML( $package->getPrettyVersion(), $plugin_name );
 				}
 		}
 

--- a/README.md
+++ b/README.md
@@ -247,141 +247,6 @@ Add the following to your composer.json file:
   {
     "type": "package",
     "package": {
-      "name": "junaidbhura/wpml-acfml",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-all-import",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-buddypress-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-cms-nav",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-contact-form-7-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-gravityforms-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-mailchimp-for-wp",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-media-translation",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-ninja-forms",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
       "name": "junaidbhura/wpml-sitepress-multilingual-cms",
       "version": "<version_number>",
       "type": "wordpress-plugin",
@@ -397,97 +262,7 @@ Add the following to your composer.json file:
   {
     "type": "package",
     "package": {
-      "name": "junaidbhura/wpml-sticky-links",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
       "name": "junaidbhura/wpml-string-translation",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-translation-management",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-types",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-woocommerce-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-wp-seo-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-wpforms",
       "version": "<version_number>",
       "type": "wordpress-plugin",
       "dist": {
@@ -514,22 +289,7 @@ Add the following to your composer.json file:
   "junaidbhura/wpae-acf-add-on": "*",
   "junaidbhura/wpae-user-add-on-pro": "*",
   "junaidbhura/wpml-sitepress-multilingual-cms": "*",
-  "junaidbhura/wpml-acfml": "*",
-  "junaidbhura/wpml-all-import": "*",
-  "junaidbhura/wpml-buddypress-multilingual": "*",
-  "junaidbhura/wpml-cms-nav": "*",
-  "junaidbhura/wpml-contact-form-7-multilingual": "*",
-  "junaidbhura/wpml-gravityforms-multilingual": "*",
-  "junaidbhura/wpml-mailchimp-for-wp": "*",
-  "junaidbhura/wpml-media-translation": "*",
-  "junaidbhura/wpml-ninja-forms": "*",
-  "junaidbhura/wpml-sticky-links": "*",
-  "junaidbhura/wpml-string-translation": "*",
-  "junaidbhura/wpml-translation-management": "*",
-  "junaidbhura/wpml-types": "*",
-  "junaidbhura/wpml-woocommerce-multilingual": "*",
-  "junaidbhura/wpml-wp-seo-multilingual": "*",
-  "junaidbhura/wpml-wpforms": "*"
+  "junaidbhura/wpml-string-translation": "*"
 },
 ```
 
@@ -640,7 +400,11 @@ For example:
 
 ### WPML Add-Ons
 
-The following WPML plugins and add-ons are supported:
+You can use any WPML add-on by simply adding it's slug like so:
+
+`junaidbhura/wpml-<addon-slug>`
+
+The following add-ons are supported:
 
 * `junaidbhura/wpml-acfml`
 * `junaidbhura/wpml-all-import`
@@ -651,7 +415,6 @@ The following WPML plugins and add-ons are supported:
 * `junaidbhura/wpml-mailchimp-for-wp`
 * `junaidbhura/wpml-media-translation`
 * `junaidbhura/wpml-ninja-forms`
-* `junaidbhura/wpml-sitepress-multilingual-cms`
 * `junaidbhura/wpml-sticky-links`
 * `junaidbhura/wpml-string-translation`
 * `junaidbhura/wpml-translation-management`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Sensitive credentials (license keys, tokens) are read from environment variables
 1. PublishPress Pro
 1. Advanced Custom Fields Extended Pro
 1. WP All Import / Export Pro / Add-Ons
+1. WPML
 
 ## Overview
 
@@ -55,6 +56,8 @@ WP_ALL_IMPORT_PRO_KEY="<wp_all_import_license_key>"
 WP_ALL_IMPORT_PRO_URL="<registered_url_for_wpai_pro>"
 WP_ALL_EXPORT_PRO_KEY="<wp_all_export_license_key>"
 WP_ALL_EXPORT_PRO_URL="<registered_url_for_wpae_pro>"
+WPML_USER_ID="<wpml_user_id>"
+WPML_KEY="<wpml_key>"
 ```
 
 Add the following to your composer.json file:
@@ -241,6 +244,262 @@ Add the following to your composer.json file:
       }
     }
   },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-sitepress-multilingual-cms",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-string-translation",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-media-translation",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-woocommerce-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-gravityforms-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-contact-form-7-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-ninja-forms",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-wpforms",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-buddypress-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-acfml",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-all-import",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-mailchimp-for-wp",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-wp-seo-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-types",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-sticky-links",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-cms-nav",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-translation-management",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+
 ],
 "require": {
   "junaidbhura/acf-extended-pro": "*",
@@ -254,7 +513,24 @@ Add the following to your composer.json file:
   "junaidbhura/wp-all-export-pro": "*",
   "junaidbhura/wpai-acf-add-on": "*",
   "junaidbhura/wpae-acf-add-on": "*",
-  "junaidbhura/wpae-user-add-on-pro": "*"
+  "junaidbhura/wpae-user-add-on-pro": "*",
+  "junaidbhura/wpml-sitepress-multilingual-cms": "*",
+  "junaidbhura/wpml-string-translation": "*",
+  "junaidbhura/wpml-media-translation": "*",
+  "junaidbhura/wpml-woocommerce-multilingual": "*",
+  "junaidbhura/wpml-gravityforms-multilingual": "*",
+  "junaidbhura/wpml-contact-form-7-multilingual": "*",
+  "junaidbhura/wpml-ninja-forms": "*",
+  "junaidbhura/wpml-wpforms": "*",
+  "junaidbhura/wpml-buddypress-multilingual": "*",
+  "junaidbhura/wpml-acfml": "*",
+  "junaidbhura/wpml-all-import": "*",
+  "junaidbhura/wpml-mailchimp-for-wp": "*",
+  "junaidbhura/wpml-wp-seo-multilingual": "*",
+  "junaidbhura/wpml-types": "*",
+  "junaidbhura/wpml-sticky-links": "*",
+  "junaidbhura/wpml-cms-nav": "*",
+  "junaidbhura/wpml-translation-management": "*"
 },
 ```
 
@@ -362,3 +638,45 @@ You can use any WP All Export Pro add-on by simply adding it's slug like so:
 For example:
 
 `junaidbhura/wpae-acf-add-on`
+
+### WPML Add-Ons
+
+You can use any WPML add-on by simply adding it's slug like so:
+
+`junaidbhura/<plugin-slug>`
+
+For example:
+
+`junaidbhura/wpml-sitepress-multilingual-cms`
+
+`junaidbhura/wpml-string-translation`
+
+`junaidbhura/wpml-media-translation`
+
+`junaidbhura/wpml-woocommerce-multilingual`
+
+`junaidbhura/wpml-gravityforms-multilingual`
+
+`junaidbhura/wpml-contact-form-7-multilingual`
+
+`junaidbhura/wpml-ninja-forms`
+
+`junaidbhura/wpml-wpforms`
+
+`junaidbhura/wpml-buddypress-multilingual`
+
+`junaidbhura/wpml-acfml`
+
+`junaidbhura/wpml-all-import`
+
+`junaidbhura/wpml-mailchimp-for-wp`
+
+`junaidbhura/wpml-wp-seo-multilingual`
+
+`junaidbhura/wpml-types`
+
+`junaidbhura/wpml-sticky-links`
+
+`junaidbhura/wpml-cms-nav`
+
+`junaidbhura/wpml-translation-management`

--- a/README.md
+++ b/README.md
@@ -247,141 +247,6 @@ Add the following to your composer.json file:
   {
     "type": "package",
     "package": {
-      "name": "junaidbhura/wpml-sitepress-multilingual-cms",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-string-translation",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-media-translation",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-woocommerce-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-gravityforms-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-contact-form-7-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-ninja-forms",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-wpforms",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-buddypress-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
       "name": "junaidbhura/wpml-acfml",
       "version": "<version_number>",
       "type": "wordpress-plugin",
@@ -412,52 +277,7 @@ Add the following to your composer.json file:
   {
     "type": "package",
     "package": {
-      "name": "junaidbhura/wpml-mailchimp-for-wp",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-wp-seo-multilingual",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-types",
-      "version": "<version_number>",
-      "type": "wordpress-plugin",
-      "dist": {
-        "type": "zip",
-        "url": "https://wpml.org/"
-      },
-      "require": {
-        "junaidbhura/composer-wp-pro-plugins": "*"
-      }
-    }
-  },
-  {
-    "type": "package",
-    "package": {
-      "name": "junaidbhura/wpml-sticky-links",
+      "name": "junaidbhura/wpml-buddypress-multilingual",
       "version": "<version_number>",
       "type": "wordpress-plugin",
       "dist": {
@@ -487,6 +307,126 @@ Add the following to your composer.json file:
   {
     "type": "package",
     "package": {
+      "name": "junaidbhura/wpml-contact-form-7-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-gravityforms-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-mailchimp-for-wp",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-media-translation",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-ninja-forms",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-sitepress-multilingual-cms",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-sticky-links",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-string-translation",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
       "name": "junaidbhura/wpml-translation-management",
       "version": "<version_number>",
       "type": "wordpress-plugin",
@@ -499,7 +439,66 @@ Add the following to your composer.json file:
       }
     }
   },
-
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-types",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-woocommerce-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-wp-seo-multilingual",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  },
+  {
+    "type": "package",
+    "package": {
+      "name": "junaidbhura/wpml-wpforms",
+      "version": "<version_number>",
+      "type": "wordpress-plugin",
+      "dist": {
+        "type": "zip",
+        "url": "https://wpml.org/"
+      },
+      "require": {
+        "junaidbhura/composer-wp-pro-plugins": "*"
+      }
+    }
+  }
 ],
 "require": {
   "junaidbhura/acf-extended-pro": "*",
@@ -515,22 +514,22 @@ Add the following to your composer.json file:
   "junaidbhura/wpae-acf-add-on": "*",
   "junaidbhura/wpae-user-add-on-pro": "*",
   "junaidbhura/wpml-sitepress-multilingual-cms": "*",
-  "junaidbhura/wpml-string-translation": "*",
-  "junaidbhura/wpml-media-translation": "*",
-  "junaidbhura/wpml-woocommerce-multilingual": "*",
-  "junaidbhura/wpml-gravityforms-multilingual": "*",
-  "junaidbhura/wpml-contact-form-7-multilingual": "*",
-  "junaidbhura/wpml-ninja-forms": "*",
-  "junaidbhura/wpml-wpforms": "*",
-  "junaidbhura/wpml-buddypress-multilingual": "*",
   "junaidbhura/wpml-acfml": "*",
   "junaidbhura/wpml-all-import": "*",
-  "junaidbhura/wpml-mailchimp-for-wp": "*",
-  "junaidbhura/wpml-wp-seo-multilingual": "*",
-  "junaidbhura/wpml-types": "*",
-  "junaidbhura/wpml-sticky-links": "*",
+  "junaidbhura/wpml-buddypress-multilingual": "*",
   "junaidbhura/wpml-cms-nav": "*",
-  "junaidbhura/wpml-translation-management": "*"
+  "junaidbhura/wpml-contact-form-7-multilingual": "*",
+  "junaidbhura/wpml-gravityforms-multilingual": "*",
+  "junaidbhura/wpml-mailchimp-for-wp": "*",
+  "junaidbhura/wpml-media-translation": "*",
+  "junaidbhura/wpml-ninja-forms": "*",
+  "junaidbhura/wpml-sticky-links": "*",
+  "junaidbhura/wpml-string-translation": "*",
+  "junaidbhura/wpml-translation-management": "*",
+  "junaidbhura/wpml-types": "*",
+  "junaidbhura/wpml-woocommerce-multilingual": "*",
+  "junaidbhura/wpml-wp-seo-multilingual": "*",
+  "junaidbhura/wpml-wpforms": "*"
 },
 ```
 
@@ -641,42 +640,22 @@ For example:
 
 ### WPML Add-Ons
 
-You can use any WPML add-on by simply adding it's slug like so:
+The following WPML plugins and add-ons are supported:
 
-`junaidbhura/<plugin-slug>`
-
-For example:
-
-`junaidbhura/wpml-sitepress-multilingual-cms`
-
-`junaidbhura/wpml-string-translation`
-
-`junaidbhura/wpml-media-translation`
-
-`junaidbhura/wpml-woocommerce-multilingual`
-
-`junaidbhura/wpml-gravityforms-multilingual`
-
-`junaidbhura/wpml-contact-form-7-multilingual`
-
-`junaidbhura/wpml-ninja-forms`
-
-`junaidbhura/wpml-wpforms`
-
-`junaidbhura/wpml-buddypress-multilingual`
-
-`junaidbhura/wpml-acfml`
-
-`junaidbhura/wpml-all-import`
-
-`junaidbhura/wpml-mailchimp-for-wp`
-
-`junaidbhura/wpml-wp-seo-multilingual`
-
-`junaidbhura/wpml-types`
-
-`junaidbhura/wpml-sticky-links`
-
-`junaidbhura/wpml-cms-nav`
-
-`junaidbhura/wpml-translation-management`
+* `junaidbhura/wpml-acfml`
+* `junaidbhura/wpml-all-import`
+* `junaidbhura/wpml-buddypress-multilingual`
+* `junaidbhura/wpml-cms-nav`
+* `junaidbhura/wpml-contact-form-7-multilingual`
+* `junaidbhura/wpml-gravityforms-multilingual`
+* `junaidbhura/wpml-mailchimp-for-wp`
+* `junaidbhura/wpml-media-translation`
+* `junaidbhura/wpml-ninja-forms`
+* `junaidbhura/wpml-sitepress-multilingual-cms`
+* `junaidbhura/wpml-sticky-links`
+* `junaidbhura/wpml-string-translation`
+* `junaidbhura/wpml-translation-management`
+* `junaidbhura/wpml-types`
+* `junaidbhura/wpml-woocommerce-multilingual`
+* `junaidbhura/wpml-wp-seo-multilingual`
+* `junaidbhura/wpml-wpforms`

--- a/plugins/WPML.php
+++ b/plugins/WPML.php
@@ -32,7 +32,7 @@ class WPML {
      * @param string $version
      * @param string $slug
      */
-    public function __construct( $version = '', $slug = 'sitepress-multilingual-cms' ) {
+    public function __construct( $version = '', $slug = 'wpml-sitepress-multilingual-cms' ) {
         $this->version = $version;
         $this->slug    = $slug;
     }
@@ -43,28 +43,28 @@ class WPML {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-        $packages = [
-            'wpml-sitepress-multilingual-cms' => 6088,
-            'wpml-string-translation' => 6092,
-            'wpml-media-translation' => 7474,
-            'wpml-woocommerce-multilingual' => 637370,
-            'wpml-gravityforms-multilingual' => 8882,
+        $packages = array(
+            'wpml-acfml'                       => 1097589,
+            'wpml-all-import'                  => 720221,
+            'wpml-buddypress-multilingual'     => 2216259,
+            'wpml-cms-nav'                     => 6096,
             'wpml-contact-form-7-multilingual' => 3156699,
-            'wpml-ninja-forms' => 5342487,
-            'wpml-wpforms' => 5368995,
-            'wpml-buddypress-multilingual' => 2216259,
-            'wpml-acfml' => 1097589,
-            'wpml-all-import' => 720221,
-            'wpml-mailchimp-for-wp' => 1442229,
-            'wpml-wp-seo-multilingual' => 3566177,
-            'wpml-types' => 1385906,
-            'wpml-sticky-links' => 6090,
-            'wpml-cms-nav' => 6096,
-            'wpml-translation-management' => 6094,
-        ];
+            'wpml-gravityforms-multilingual'   => 8882,
+            'wpml-mailchimp-for-wp'            => 1442229,
+            'wpml-media-translation'           => 7474,
+            'wpml-ninja-forms'                 => 5342487,
+            'wpml-sitepress-multilingual-cms'  => 6088,
+            'wpml-sticky-links'                => 6090,
+            'wpml-string-translation'          => 6092,
+            'wpml-translation-management'      => 6094,
+            'wpml-types'                       => 1385906,
+            'wpml-woocommerce-multilingual'    => 637370,
+            'wpml-wp-seo-multilingual'         => 3566177,
+            'wpml-wpforms'                     => 5368995,
+        );
 
-        if (array_key_exists($this->slug, $packages)) {
-            return 'https://wpml.org/?download='. $packages[$this->slug] .'&user_id='. getenv( 'WPML_USER_ID' ) .'&subscription_key='. getenv( 'WPML_KEY' ) .'&version=' . $this->version;
+        if ( array_key_exists( $this->slug, $packages ) ) {
+            return 'https://wpml.org/?download=' . $packages[ $this->slug ] . '&user_id=' . getenv( 'WPML_USER_ID' ) . '&subscription_key=' . getenv( 'WPML_KEY' ) . '&version=' . $this->version;
         }
 	}
 

--- a/plugins/WPML.php
+++ b/plugins/WPML.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * ACF Pro Plugin.
+ *
+ * @package Junaidbhura\Composer\WPProPlugins\Plugins
+ */
+
+namespace Junaidbhura\Composer\WPProPlugins\Plugins;
+
+/**
+ * AcfPro class.
+ */
+class WPML {
+
+    /**
+     * The version number of the plugin to download.
+     *
+     * @var string Version number.
+     */
+    protected $version = '';
+
+    /**
+     * The slug of which plugin to download.
+     *
+     * @var string Plugin slug.
+     */
+    protected $slug = '';
+
+    /**
+     * WpAiPro constructor.
+     *
+     * @param string $version
+     * @param string $slug
+     */
+    public function __construct( $version = '', $slug = 'sitepress-multilingual-cms' ) {
+        $this->version = $version;
+        $this->slug    = $slug;
+    }
+
+	/**
+	 * Get the download URL for this plugin.
+	 *
+	 * @return string
+	 */
+	public function getDownloadUrl() {
+        $packages = [
+            'wpml-sitepress-multilingual-cms' => 6088,
+            'wpml-string-translation' => 6092,
+            'wpml-media-translation' => 7474,
+            'wpml-woocommerce-multilingual' => 637370,
+            'wpml-gravityforms-multilingual' => 8882,
+            'wpml-contact-form-7-multilingual' => 3156699,
+            'wpml-ninja-forms' => 5342487,
+            'wpml-wpforms' => 5368995,
+            'wpml-buddypress-multilingual' => 2216259,
+            'wpml-acfml' => 1097589,
+            'wpml-all-import' => 720221,
+            'wpml-mailchimp-for-wp' => 1442229,
+            'wpml-wp-seo-multilingual' => 3566177,
+            'wpml-types' => 1385906,
+            'wpml-sticky-links' => 6090,
+            'wpml-cms-nav' => 6096,
+            'wpml-translation-management' => 6094,
+        ];
+
+        if (array_key_exists($this->slug, $packages)) {
+            return 'https://wpml.org/?download='. $packages[$this->slug] .'&user_id='. getenv( 'WPML_USER_ID' ) .'&subscription_key='. getenv( 'WPML_KEY' ) .'&version=' . $this->version;
+        }
+	}
+
+}

--- a/plugins/WPML.php
+++ b/plugins/WPML.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ACF Pro Plugin.
+ * WPML Plugin.
  *
  * @package Junaidbhura\Composer\WPProPlugins\Plugins
  */
@@ -8,9 +8,9 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 /**
- * AcfPro class.
+ * Wpml class.
  */
-class WPML {
+class Wpml {
 
     /**
      * The version number of the plugin to download.
@@ -27,7 +27,7 @@ class WPML {
     protected $slug = '';
 
     /**
-     * WpAiPro constructor.
+     * Wpml constructor.
      *
      * @param string $version
      * @param string $slug

--- a/plugins/WPML.php
+++ b/plugins/WPML.php
@@ -14,15 +14,15 @@ use UnexpectedValueException;
  */
 class Wpml extends AbstractPlugin {
 
-    /**
-     * Wpml constructor.
-     *
-     * @param string $version
-     * @param string $slug
-     */
-    public function __construct( $version = '', $slug = 'wpml-sitepress-multilingual-cms' ) {
-        parent::__construct( $version, $slug );
-    }
+	/**
+	 * Wpml constructor.
+	 *
+	 * @param string $version
+	 * @param string $slug
+	 */
+	public function __construct( $version = '', $slug = 'wpml-sitepress-multilingual-cms' ) {
+		parent::__construct( $version, $slug );
+	}
 
 	/**
 	 * Get the download URL for this plugin.
@@ -30,34 +30,34 @@ class Wpml extends AbstractPlugin {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-        $packages = array(
-            'wpml-acfml'                       => 1097589,
-            'wpml-all-import'                  => 720221,
-            'wpml-buddypress-multilingual'     => 2216259,
-            'wpml-cms-nav'                     => 6096,
-            'wpml-contact-form-7-multilingual' => 3156699,
-            'wpml-gravityforms-multilingual'   => 8882,
-            'wpml-mailchimp-for-wp'            => 1442229,
-            'wpml-media-translation'           => 7474,
-            'wpml-ninja-forms'                 => 5342487,
-            'wpml-sitepress-multilingual-cms'  => 6088,
-            'wpml-sticky-links'                => 6090,
-            'wpml-string-translation'          => 6092,
-            'wpml-translation-management'      => 6094,
-            'wpml-types'                       => 1385906,
-            'wpml-woocommerce-multilingual'    => 637370,
-            'wpml-wp-seo-multilingual'         => 3566177,
-            'wpml-wpforms'                     => 5368995,
-        );
+		$packages = array(
+			'wpml-acfml'                       => 1097589,
+			'wpml-all-import'                  => 720221,
+			'wpml-buddypress-multilingual'     => 2216259,
+			'wpml-cms-nav'                     => 6096,
+			'wpml-contact-form-7-multilingual' => 3156699,
+			'wpml-gravityforms-multilingual'   => 8882,
+			'wpml-mailchimp-for-wp'            => 1442229,
+			'wpml-media-translation'           => 7474,
+			'wpml-ninja-forms'                 => 5342487,
+			'wpml-sitepress-multilingual-cms'  => 6088,
+			'wpml-sticky-links'                => 6090,
+			'wpml-string-translation'          => 6092,
+			'wpml-translation-management'      => 6094,
+			'wpml-types'                       => 1385906,
+			'wpml-woocommerce-multilingual'    => 637370,
+			'wpml-wp-seo-multilingual'         => 3566177,
+			'wpml-wpforms'                     => 5368995,
+		);
 
-        if ( ! array_key_exists( $this->slug, $packages ) ) {
-            throw new UnexpectedValueException( sprintf(
-                'Could not find a matching package for %s. Check the package spelling and that the package is supported',
-                'junaidbhura/' . $this->slug
-            ) );
-        }
+		if ( ! array_key_exists( $this->slug, $packages ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Could not find a matching package for %s. Check the package spelling and that the package is supported',
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
-        return 'https://wpml.org/?download=' . $packages[ $this->slug ] . '&user_id=' . getenv( 'WPML_USER_ID' ) . '&subscription_key=' . getenv( 'WPML_KEY' ) . '&version=' . $this->version;
+		return 'https://wpml.org/?download=' . $packages[ $this->slug ] . '&user_id=' . getenv( 'WPML_USER_ID' ) . '&subscription_key=' . getenv( 'WPML_KEY' ) . '&version=' . $this->version;
 	}
 
 }

--- a/plugins/WPML.php
+++ b/plugins/WPML.php
@@ -7,24 +7,12 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use UnexpectedValueException;
+
 /**
  * Wpml class.
  */
-class Wpml {
-
-    /**
-     * The version number of the plugin to download.
-     *
-     * @var string Version number.
-     */
-    protected $version = '';
-
-    /**
-     * The slug of which plugin to download.
-     *
-     * @var string Plugin slug.
-     */
-    protected $slug = '';
+class Wpml extends AbstractPlugin {
 
     /**
      * Wpml constructor.
@@ -33,8 +21,7 @@ class Wpml {
      * @param string $slug
      */
     public function __construct( $version = '', $slug = 'wpml-sitepress-multilingual-cms' ) {
-        $this->version = $version;
-        $this->slug    = $slug;
+        parent::__construct( $version, $slug );
     }
 
 	/**
@@ -63,9 +50,14 @@ class Wpml {
             'wpml-wpforms'                     => 5368995,
         );
 
-        if ( array_key_exists( $this->slug, $packages ) ) {
-            return 'https://wpml.org/?download=' . $packages[ $this->slug ] . '&user_id=' . getenv( 'WPML_USER_ID' ) . '&subscription_key=' . getenv( 'WPML_KEY' ) . '&version=' . $this->version;
+        if ( ! array_key_exists( $this->slug, $packages ) ) {
+            throw new UnexpectedValueException( sprintf(
+                'Could not find a matching package for %s. Check the package spelling and that the package is supported',
+                'junaidbhura/' . $this->slug
+            ) );
         }
+
+        return 'https://wpml.org/?download=' . $packages[ $this->slug ] . '&user_id=' . getenv( 'WPML_USER_ID' ) . '&subscription_key=' . getenv( 'WPML_KEY' ) . '&version=' . $this->version;
 	}
 
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] Issue: #43
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [X] My code has proper inline documentation.

## Description

Supersedes PR #42 to add support for WPML and add-ons.

This pull request includes the suggestions (coding style and typo fixes) from the former as well latest changes to the `master` branch.

## How has this been tested?

I'm testing this on a client project that uses ACF Pro, ACF Extended Pro, Ninja Forms, PublishPress Pro, and WPML.