### PR TITLE
Improve error handling and logic

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -22,14 +22,15 @@ class Http {
 	public function post( $url = '', $args = array() ) {
 		$curl_handle = curl_init();
 		curl_setopt( $curl_handle, CURLOPT_URL, $url );
-		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, 1 );
+		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $curl_handle, CURLOPT_FOLLOWLOCATION, true );
-		curl_setopt( $curl_handle, CURLOPT_SSL_VERIFYPEER, 0 );
-		curl_setopt( $curl_handle, CURLOPT_SSL_VERIFYHOST, 0 );
+		curl_setopt( $curl_handle, CURLOPT_SSL_VERIFYPEER, false );
+		curl_setopt( $curl_handle, CURLOPT_SSL_VERIFYHOST, false );
 		curl_setopt( $curl_handle, CURLOPT_CUSTOMREQUEST, 'POST' );
 		if ( ! empty( $args ) ) {
 			curl_setopt( $curl_handle, CURLOPT_POSTFIELDS, http_build_query( $args, '', '&' ) );
 		}
+
 		$response = curl_exec( $curl_handle );
 		curl_close( $curl_handle );
 
@@ -44,15 +45,15 @@ class Http {
 	 * @return mixed
 	 */
 	public function get( $url = '', $args = array() ) {
-		$query_string = '';
+		if ( ! empty( $args ) ) {
+			$url .= '?' . http_build_query( $args, '', '&' );
+		}
 
 		$curl_handle = curl_init();
-		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, 1 );
+		curl_setopt( $curl_handle, CURLOPT_URL, $url );
+		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $curl_handle, CURLOPT_FOLLOWLOCATION, true );
-		if ( ! empty( $args ) ) {
-			$query_string = http_build_query( $args, '', '&' );
-		}
-		curl_setopt( $curl_handle, CURLOPT_URL, $url . '?' . $query_string );
+
 		$response = curl_exec( $curl_handle );
 		curl_close( $curl_handle );
 

--- a/src/Http.php
+++ b/src/Http.php
@@ -21,7 +21,7 @@ class Http {
 	 * @param  array<string, mixed>  $args Arguments to POST.
 	 * @return string
 	 */
-	public function post( $url = '', $args = array() ) {
+	public function post( $url, $args = array() ) {
 		$curl_handle = curl_init();
 		curl_setopt( $curl_handle, CURLOPT_URL, $url );
 		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, true );
@@ -44,7 +44,7 @@ class Http {
 	 * @param  array<string, mixed>  $args Arguments to add to request.
 	 * @return string
 	 */
-	public function get( $url = '', $args = array() ) {
+	public function get( $url, $args = array() ) {
 		if ( ! empty( $args ) ) {
 			$url .= '?' . http_build_query( $args, '', '&' );
 		}

--- a/src/Http.php
+++ b/src/Http.php
@@ -24,9 +24,6 @@ class Http {
 	public function post( $url, $args = array() ) {
 		$curl_handle = curl_init();
 		curl_setopt( $curl_handle, CURLOPT_URL, $url );
-		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, true );
-		curl_setopt( $curl_handle, CURLOPT_FOLLOWLOCATION, true );
-		curl_setopt( $curl_handle, CURLOPT_FAILONERROR, true );
 		curl_setopt( $curl_handle, CURLOPT_SSL_VERIFYPEER, false );
 		curl_setopt( $curl_handle, CURLOPT_SSL_VERIFYHOST, false );
 		curl_setopt( $curl_handle, CURLOPT_CUSTOMREQUEST, 'POST' );
@@ -51,9 +48,6 @@ class Http {
 
 		$curl_handle = curl_init();
 		curl_setopt( $curl_handle, CURLOPT_URL, $url );
-		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, true );
-		curl_setopt( $curl_handle, CURLOPT_FOLLOWLOCATION, true );
-		curl_setopt( $curl_handle, CURLOPT_FAILONERROR, true );
 
 		return $this->request( $curl_handle );
 	}
@@ -61,10 +55,15 @@ class Http {
 	/**
 	 * @param  \CurlHandle|resource $curl_handle The cURL handler.
 	 * @throws RuntimeException If the request failed or the response is invalid.
-	 * @return string
+	 * @return string The response body.
 	 */
 	protected function request( $curl_handle ) {
+		curl_setopt( $curl_handle, CURLOPT_RETURNTRANSFER, true );
+		curl_setopt( $curl_handle, CURLOPT_FOLLOWLOCATION, true );
+		curl_setopt( $curl_handle, CURLOPT_FAILONERROR, true );
+
 		$response = curl_exec( $curl_handle );
+
 		$curl_errno = curl_errno( $curl_handle );
 		$curl_error = curl_error( $curl_handle );
 		curl_close( $curl_handle );

--- a/src/Plugins/AbstractEddPlugin.php
+++ b/src/Plugins/AbstractEddPlugin.php
@@ -8,7 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Composer\Semver\Semver;
-use RuntimeException;
+use Exception;
 use UnexpectedValueException;
 
 /**
@@ -32,7 +32,7 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 	public function getDownloadUrl() {
 		try {
 			$response = json_decode( $this->getDownloadUrlFromApi(), true );
-		} catch ( RuntimeException $e ) {
+		} catch ( Exception $e ) {
 			$details = $e->getMessage();
 			if ( $details ) {
 				$details = PHP_EOL . $details;

--- a/src/Plugins/AbstractEddPlugin.php
+++ b/src/Plugins/AbstractEddPlugin.php
@@ -65,7 +65,8 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 			) );
 		}
 
-		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version && ! Semver::satisfies( $response['new_version'], $this->version ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected download version from API (%s) to match installed version (%s) of package %s',
 				$response['new_version'],

--- a/src/Plugins/AbstractEddPlugin.php
+++ b/src/Plugins/AbstractEddPlugin.php
@@ -19,26 +19,27 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 	 * Get the download URL for this plugin.
 	 *
 	 * @param  array<string, mixed> $response The EDD API response.
+	 * @throws UnexpectedValueException If the response is invalid or versions do not match.
 	 * @return string
 	 */
 	protected function extractDownloadUrl( array $response ) {
 		if ( empty( $response['download_link'] ) || ! is_string( $response['download_link'] ) ) {
 			throw new UnexpectedValueException( sprintf(
-				'Expected a valid download URL for package %s',
+				'Expected a valid download URL from API for package %s',
 				'junaidbhura/' . $this->slug
 			) );
 		}
 
 		if ( empty( $response['new_version'] ) || ! is_scalar( $response['new_version'] ) ) {
 			throw new UnexpectedValueException( sprintf(
-				'Expected a valid download version number for package %s',
+				'Expected a valid download version number from API for package %s',
 				'junaidbhura/' . $this->slug
 			) );
 		}
 
 		if ( ! Semver::satisfies( $response['new_version'], $this->version ) ) {
 			throw new UnexpectedValueException( sprintf(
-				'Expected download version (%s) to match installed version (%s) of package %s',
+				'Expected download version from API (%s) to match installed version (%s) of package %s',
 				$response['new_version'],
 				$this->version,
 				'junaidbhura/' . $this->slug

--- a/src/Plugins/AbstractEddPlugin.php
+++ b/src/Plugins/AbstractEddPlugin.php
@@ -40,28 +40,28 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 
 			throw new UnexpectedValueException( sprintf(
 				'Could not query API for package %s. Please try again later.' . $details,
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 
 		if ( ! is_array( $response ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a JSON object from API for package %s',
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 
 		if ( empty( $response['download_link'] ) || ! is_string( $response['download_link'] ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download URL from API for package %s',
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 
 		if ( empty( $response['new_version'] ) || ! is_scalar( $response['new_version'] ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download version number from API for package %s',
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 
@@ -71,7 +71,7 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 				'Expected download version from API (%s) to match installed version (%s) of package %s',
 				$response['new_version'],
 				$this->version,
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 

--- a/src/Plugins/AbstractEddPlugin.php
+++ b/src/Plugins/AbstractEddPlugin.php
@@ -31,34 +31,77 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 	 */
 	public function getDownloadUrl() {
 		try {
-			$response = json_decode( $this->getDownloadUrlFromApi(), true );
+			$response = $this->getDownloadUrlFromApi();
 		} catch ( Exception $e ) {
-			$details = $e->getMessage();
-			if ( $details ) {
-				$details = PHP_EOL . $details;
+			$details = [];
+
+			$error = $e->getMessage();
+			if ( $error ) {
+				$details[] = 'HTTP Error: ' . $error;
 			}
 
-			throw new UnexpectedValueException( sprintf(
-				'Could not query API for package %s. Please try again later.' . $details,
+			$message = sprintf(
+				'Could not query API for package %s. Please try again later.',
 				$this->getPackageName()
-			) );
+			);
+
+			if ( $details ) {
+				$message .= PHP_EOL . PHP_EOL . implode( PHP_EOL . PHP_EOL, $details );
+			}
+
+			throw new UnexpectedValueException( $message );
 		}
 
-		if ( ! is_array( $response ) ) {
-			throw new UnexpectedValueException( sprintf(
-				'Expected a JSON object from API for package %s',
+		try {
+			/**
+			 * @todo When the Composer plugin drops support for PHP 5,
+			 *    use the `json_decode()` function's `JSON_THROW_ON_ERROR` flag,
+			 *    introduced in PHP 7.3, to simplify error handling.
+			 */
+			$data = json_decode( $response, true );
+
+			if ( json_last_error() !== JSON_ERROR_NONE ) {
+				throw new Exception(
+					json_last_error_msg(),
+					json_last_error()
+				);
+			}
+
+			if ( ! is_array( $data ) ) {
+				throw new UnexpectedValueException(
+					'Expected a data structure'
+				);
+			}
+		} catch ( Exception $e ) {
+			$details = [
+				'json_decode(): ' . $e->getMessage(),
+			];
+
+			$response_length = mb_strlen( $response );
+			if ( $response_length > 0 ) {
+				$details[] = '    ' . mb_substr( $response, 0, 100 ) . ( $response_length > 100 ? '...' : '' );
+			}
+
+			$message = sprintf(
+				'Expected a data structure from API for package %s. Please try again later.',
 				$this->getPackageName()
-			) );
+			);
+
+			if ( $details ) {
+				$message .= PHP_EOL . PHP_EOL . implode( PHP_EOL . PHP_EOL, $details );
+			}
+
+			throw new UnexpectedValueException( $message );
 		}
 
-		if ( empty( $response['download_link'] ) || ! is_string( $response['download_link'] ) ) {
+		if ( empty( $data['download_link'] ) || ! is_string( $data['download_link'] ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download URL from API for package %s',
 				$this->getPackageName()
 			) );
 		}
 
-		if ( empty( $response['new_version'] ) || ! is_scalar( $response['new_version'] ) ) {
+		if ( empty( $data['new_version'] ) || ! is_scalar( $data['new_version'] ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download version number from API for package %s',
 				$this->getPackageName()
@@ -66,16 +109,16 @@ abstract class AbstractEddPlugin extends AbstractPlugin {
 		}
 
 		// If no version is specified, we are fetching the latest version.
-		if ( $this->version && ! Semver::satisfies( $response['new_version'], $this->version ) ) {
+		if ( $this->version && ! Semver::satisfies( $data['new_version'], $this->version ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected download version from API (%s) to match installed version (%s) of package %s',
-				$response['new_version'],
+				$data['new_version'],
 				$this->version,
 				$this->getPackageName()
 			) );
 		}
 
-		return $response['download_link'];
+		return $data['download_link'];
 	}
 
 }

--- a/src/Plugins/AbstractPlugin.php
+++ b/src/Plugins/AbstractPlugin.php
@@ -15,14 +15,14 @@ abstract class AbstractPlugin {
 	/**
 	 * The version number of the plugin to download.
 	 *
-	 * @var string Version number.
+	 * @var string
 	 */
 	protected $version = '';
 
 	/**
-	 * The slug of which plugin to download.
+	 * The name of the plugin to download.
 	 *
-	 * @var string Plugin slug.
+	 * @var string
 	 */
 	protected $slug = '';
 
@@ -30,6 +30,7 @@ abstract class AbstractPlugin {
 	 * AbstractPlugin constructor.
 	 *
 	 * @param string $version
+	 * @param string $slug
 	 */
 	public function __construct( $version = '', $slug = '' ) {
 		$this->version = $version;

--- a/src/Plugins/AbstractPlugin.php
+++ b/src/Plugins/AbstractPlugin.php
@@ -44,4 +44,13 @@ abstract class AbstractPlugin {
 	 */
 	abstract public function getDownloadUrl();
 
+	/**
+	 * Get the plugin's Composer package name with vendor.
+	 *
+	 * @return string
+	 */
+	protected function getPackageName() {
+		return 'junaidbhura/' . $this->slug;
+	}
+
 }

--- a/src/Plugins/AcfExtendedPro.php
+++ b/src/Plugins/AcfExtendedPro.php
@@ -21,7 +21,7 @@ class AcfExtendedPro extends AbstractEddPlugin {
 	 */
 	public function getDownloadUrl() {
 		$http     = new Http();
-		$response = json_decode( $http->post( 'https://acf-extended.com', array(
+		$response = json_decode( $http->get( 'https://acf-extended.com', array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'ACFE_PRO_KEY' ),
 			'item_name'  => 'ACF Extended Pro',

--- a/src/Plugins/AcfExtendedPro.php
+++ b/src/Plugins/AcfExtendedPro.php
@@ -27,8 +27,12 @@ class AcfExtendedPro extends AbstractEddPlugin {
 			'license'    => getenv( 'ACFE_PRO_KEY' ),
 			'item_name'  => 'ACF Extended Pro',
 			'url'        => getenv( 'ACFE_PRO_URL' ),
-			'version'    => $this->version,
 		);
+
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version ) {
+			$api_query['version'] = $this->version;
+		}
 
 		$api_url = 'https://acf-extended.com';
 

--- a/src/Plugins/AcfExtendedPro.php
+++ b/src/Plugins/AcfExtendedPro.php
@@ -8,7 +8,6 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
-use UnexpectedValueException;
 
 /**
  * AcfExtendedPro class.
@@ -16,29 +15,20 @@ use UnexpectedValueException;
 class AcfExtendedPro extends AbstractEddPlugin {
 
 	/**
-	 * Get the download URL for this plugin.
+	 * Get the download URL for this plugin from its API.
 	 *
-	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
-	public function getDownloadUrl() {
-		$http     = new Http();
-		$response = json_decode( $http->get( 'https://acf-extended.com', array(
+	protected function getDownloadUrlFromApi() {
+		$http = new Http();
+
+		return $http->post( 'https://acf-extended.com', array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'ACFE_PRO_KEY' ),
 			'item_name'  => 'ACF Extended Pro',
 			'url'        => getenv( 'ACFE_PRO_URL' ),
 			'version'    => $this->version,
-		) ), true );
-
-		if ( ! is_array( $response ) ) {
-			throw new UnexpectedValueException( sprintf(
-				'Expected a JSON object from API for package %s',
-				'junaidbhura/' . $this->slug
-			) );
-		}
-
-		return $this->extractDownloadUrl( $response );
+		) );
 	}
 
 }

--- a/src/Plugins/AcfExtendedPro.php
+++ b/src/Plugins/AcfExtendedPro.php
@@ -22,13 +22,17 @@ class AcfExtendedPro extends AbstractEddPlugin {
 	protected function getDownloadUrlFromApi() {
 		$http = new Http();
 
-		return $http->get( 'https://acf-extended.com', array(
+		$api_query = array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'ACFE_PRO_KEY' ),
 			'item_name'  => 'ACF Extended Pro',
 			'url'        => getenv( 'ACFE_PRO_URL' ),
 			'version'    => $this->version,
-		) );
+		);
+
+		$api_url = 'https://acf-extended.com';
+
+		return $http->get( $api_url, $api_query );
 	}
 
 }

--- a/src/Plugins/AcfExtendedPro.php
+++ b/src/Plugins/AcfExtendedPro.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use UnexpectedValueException;
 
 /**
  * AcfExtendedPro class.
@@ -17,6 +18,7 @@ class AcfExtendedPro extends AbstractEddPlugin {
 	/**
 	 * Get the download URL for this plugin.
 	 *
+	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
 	public function getDownloadUrl() {
@@ -28,6 +30,13 @@ class AcfExtendedPro extends AbstractEddPlugin {
 			'url'        => getenv( 'ACFE_PRO_URL' ),
 			'version'    => $this->version,
 		) ), true );
+
+		if ( ! is_array( $response ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a JSON object from API for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
 		return $this->extractDownloadUrl( $response );
 	}

--- a/src/Plugins/AcfExtendedPro.php
+++ b/src/Plugins/AcfExtendedPro.php
@@ -22,7 +22,7 @@ class AcfExtendedPro extends AbstractEddPlugin {
 	protected function getDownloadUrlFromApi() {
 		$http = new Http();
 
-		return $http->post( 'https://acf-extended.com', array(
+		return $http->get( 'https://acf-extended.com', array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'ACFE_PRO_KEY' ),
 			'item_name'  => 'ACF Extended Pro',

--- a/src/Plugins/AcfPro.php
+++ b/src/Plugins/AcfPro.php
@@ -18,12 +18,16 @@ class AcfPro extends AbstractPlugin {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		return 'https://connect.advancedcustomfields.com/index.php?' . http_build_query( array(
+		$api_query = array(
 			'p' => 'pro',
 			'a' => 'download',
 			'k' => getenv( 'ACF_PRO_KEY' ),
 			't' => $this->version,
-		), '', '&' );
+		);
+
+		$api_url = 'https://connect.advancedcustomfields.com/index.php';
+
+		return $api_url . '?' . http_build_query( $api_query, '', '&' );
 	}
 
 }

--- a/src/Plugins/AcfPro.php
+++ b/src/Plugins/AcfPro.php
@@ -22,8 +22,12 @@ class AcfPro extends AbstractPlugin {
 			'p' => 'pro',
 			'a' => 'download',
 			'k' => getenv( 'ACF_PRO_KEY' ),
-			't' => $this->version,
 		);
+
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version ) {
+			$api_query['t'] = $this->version;
+		}
 
 		$api_url = 'https://connect.advancedcustomfields.com/index.php';
 

--- a/src/Plugins/AcfPro.php
+++ b/src/Plugins/AcfPro.php
@@ -18,7 +18,12 @@ class AcfPro extends AbstractPlugin {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		return 'https://connect.advancedcustomfields.com/index.php?p=pro&a=download&k=' . getenv( 'ACF_PRO_KEY' ) . '&t=' . $this->version;
+		return 'https://connect.advancedcustomfields.com/index.php?' . http_build_query( array(
+			'p' => 'pro',
+			'a' => 'download',
+			'k' => getenv( 'ACF_PRO_KEY' ),
+			't' => $this->version,
+		), '', '&' );
 	}
 
 }

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -32,7 +32,7 @@ class GravityForms extends AbstractPlugin {
 	 */
 	public function getDownloadUrl() {
 		$http     = new Http();
-		$response = unserialize( $http->post( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php', array(
+		$response = unserialize( $http->get( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php', array(
 			'op'   => 'get_plugin',
 			'slug' => $this->slug,
 			'key'  => getenv( 'GRAVITY_FORMS_KEY' ),

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -53,21 +53,21 @@ class GravityForms extends AbstractPlugin {
 
 			throw new UnexpectedValueException( sprintf(
 				'Could not query API for package %s. Please try again later.' . $details,
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 
 		if ( ! is_array( $response ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a serialized object from API for package %s',
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 
 		if ( empty( $response['download_url_latest'] ) || ! is_string( $response['download_url_latest'] ) ) {
 			throw new UnexpectedValueException( sprintf(
 				'Expected a valid download URL for package %s',
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use RuntimeException;
 use UnexpectedValueException;
 
 /**
@@ -32,12 +33,25 @@ class GravityForms extends AbstractPlugin {
 	 * @return string
 	 */
 	public function getDownloadUrl() {
-		$http     = new Http();
-		$response = unserialize( $http->get( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php', array(
-			'op'   => 'get_plugin',
-			'slug' => $this->slug,
-			'key'  => getenv( 'GRAVITY_FORMS_KEY' ),
-		) ) );
+		$http = new Http();
+
+		try {
+			$response = unserialize( $http->get( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php', array(
+				'op'   => 'get_plugin',
+				'slug' => $this->slug,
+				'key'  => getenv( 'GRAVITY_FORMS_KEY' ),
+			) ) );
+		} catch ( RuntimeException $e ) {
+			$details = $e->getMessage();
+			if ( $details ) {
+				$details = PHP_EOL . $details;
+			}
+
+			throw new UnexpectedValueException( sprintf(
+				'Could not query API for package %s. Please try again later.' . $details,
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
 		if ( ! is_array( $response ) ) {
 			throw new UnexpectedValueException( sprintf(

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -28,6 +28,7 @@ class GravityForms extends AbstractPlugin {
 	/**
 	 * Get the download URL for this plugin.
 	 *
+	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
 	public function getDownloadUrl() {
@@ -37,6 +38,13 @@ class GravityForms extends AbstractPlugin {
 			'slug' => $this->slug,
 			'key'  => getenv( 'GRAVITY_FORMS_KEY' ),
 		) ) );
+
+		if ( ! is_array( $response ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a serialized object from API for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
 		if ( empty( $response['download_url_latest'] ) || ! is_string( $response['download_url_latest'] ) ) {
 			throw new UnexpectedValueException( sprintf(

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -7,8 +7,8 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
+use Exception;
 use Junaidbhura\Composer\WPProPlugins\Http;
-use RuntimeException;
 use UnexpectedValueException;
 
 /**
@@ -45,7 +45,7 @@ class GravityForms extends AbstractPlugin {
 
 		try {
 			$response = unserialize( $http->get( $api_url, $api_query ) );
-		} catch ( RuntimeException $e ) {
+		} catch ( Exception $e ) {
 			$details = $e->getMessage();
 			if ( $details ) {
 				$details = PHP_EOL . $details;

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -32,7 +32,11 @@ class GravityForms extends AbstractPlugin {
 	 */
 	public function getDownloadUrl() {
 		$http     = new Http();
-		$response = unserialize( $http->post( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php?op=get_plugin&slug=' . $this->slug . '&key=' . getenv( 'GRAVITY_FORMS_KEY' ) ) );
+		$response = unserialize( $http->post( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php', array(
+			'op'   => 'get_plugin',
+			'slug' => $this->slug,
+			'key'  => getenv( 'GRAVITY_FORMS_KEY' ),
+		) ) );
 
 		if ( empty( $response['download_url_latest'] ) || ! is_string( $response['download_url_latest'] ) ) {
 			throw new UnexpectedValueException( sprintf(

--- a/src/Plugins/GravityForms.php
+++ b/src/Plugins/GravityForms.php
@@ -35,12 +35,16 @@ class GravityForms extends AbstractPlugin {
 	public function getDownloadUrl() {
 		$http = new Http();
 
+		$api_query = array(
+			'op'   => 'get_plugin',
+			'slug' => $this->slug,
+			'key'  => getenv( 'GRAVITY_FORMS_KEY' ),
+		);
+
+		$api_url = 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php';
+
 		try {
-			$response = unserialize( $http->get( 'https://gravityapi.com/wp-content/plugins/gravitymanager/api.php', array(
-				'op'   => 'get_plugin',
-				'slug' => $this->slug,
-				'key'  => getenv( 'GRAVITY_FORMS_KEY' ),
-			) ) );
+			$response = unserialize( $http->get( $api_url, $api_query ) );
 		} catch ( RuntimeException $e ) {
 			$details = $e->getMessage();
 			if ( $details ) {

--- a/src/Plugins/NinjaForms.php
+++ b/src/Plugins/NinjaForms.php
@@ -313,13 +313,17 @@ class NinjaForms extends AbstractEddPlugin {
 
 		$http = new Http();
 
-		return $http->get( 'https://ninjaforms.com', array(
+		$api_query = array(
 			'edd_action' => 'get_version',
 			'license'    => $license,
 			'item_name'  => $name,
 			'url'        => $url,
 			'version'    => $this->version,
-		) );
+		);
+
+		$api_url = 'https://ninjaforms.com';
+
+		return $http->get( $api_url, $api_query );
 	}
 
 }

--- a/src/Plugins/NinjaForms.php
+++ b/src/Plugins/NinjaForms.php
@@ -9,7 +9,6 @@ namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
 use InvalidArgumentException;
-use UnexpectedValueException;
 
 /**
  * NinjaForms class.
@@ -17,13 +16,12 @@ use UnexpectedValueException;
 class NinjaForms extends AbstractEddPlugin {
 
 	/**
-	 * Get the download URL for this plugin.
+	 * Get the download URL for this plugin from its API.
 	 *
 	 * @throws InvalidArgumentException If the package is unsupported.
-	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
-	public function getDownloadUrl() {
+	protected function getDownloadUrlFromApi() {
 		$name    = '';
 		$env     = null;
 		/**
@@ -313,23 +311,15 @@ class NinjaForms extends AbstractEddPlugin {
 			$url     = ( getenv( "NINJA_FORMS_{$env}_URL" ) ?: $url );
 		}
 
-		$http     = new Http();
-		$response = json_decode( $http->get( 'https://ninjaforms.com', array(
+		$http = new Http();
+
+		return $http->get( 'https://ninjaforms.com', array(
 			'edd_action' => 'get_version',
 			'license'    => $license,
 			'item_name'  => $name,
 			'url'        => $url,
 			'version'    => $this->version,
-		) ), true );
-
-		if ( ! is_array( $response ) ) {
-			throw new UnexpectedValueException( sprintf(
-				'Expected a JSON object from API for package %s',
-				'junaidbhura/' . $this->slug
-			) );
-		}
-
-		return $this->extractDownloadUrl( $response );
+		) );
 	}
 
 }

--- a/src/Plugins/NinjaForms.php
+++ b/src/Plugins/NinjaForms.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -18,6 +19,8 @@ class NinjaForms extends AbstractEddPlugin {
 	/**
 	 * Get the download URL for this plugin.
 	 *
+	 * @throws InvalidArgumentException If the package is unsupported.
+	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
 	public function getDownloadUrl() {
@@ -296,7 +299,7 @@ class NinjaForms extends AbstractEddPlugin {
 				break;
 
 			default:
-				throw new UnexpectedValueException( sprintf(
+				throw new InvalidArgumentException( sprintf(
 					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
 					'junaidbhura/' . $this->slug
 				) );
@@ -318,6 +321,13 @@ class NinjaForms extends AbstractEddPlugin {
 			'url'        => $url,
 			'version'    => $this->version,
 		) ), true );
+
+		if ( ! is_array( $response ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a JSON object from API for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
 		return $this->extractDownloadUrl( $response );
 	}

--- a/src/Plugins/NinjaForms.php
+++ b/src/Plugins/NinjaForms.php
@@ -318,8 +318,12 @@ class NinjaForms extends AbstractEddPlugin {
 			'license'    => $license,
 			'item_name'  => $name,
 			'url'        => $url,
-			'version'    => $this->version,
 		);
+
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version ) {
+			$api_query['version'] = $this->version;
+		}
 
 		$api_url = 'https://ninjaforms.com';
 

--- a/src/Plugins/NinjaForms.php
+++ b/src/Plugins/NinjaForms.php
@@ -299,7 +299,7 @@ class NinjaForms extends AbstractEddPlugin {
 			default:
 				throw new InvalidArgumentException( sprintf(
 					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
-					'junaidbhura/' . $this->slug
+					$this->getPackageName()
 				) );
 		}
 

--- a/src/Plugins/PolylangPro.php
+++ b/src/Plugins/PolylangPro.php
@@ -22,13 +22,17 @@ class PolylangPro extends AbstractEddPlugin {
 	protected function getDownloadUrlFromApi() {
 		$http = new Http();
 
-		return $http->get( 'https://polylang.pro', array(
+		$api_query = array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'POLYLANG_PRO_KEY' ),
 			'item_name'  => 'Polylang Pro',
 			'url'        => getenv( 'POLYLANG_PRO_URL' ),
 			'version'    => $this->version,
-		) );
+		);
+
+		$api_url = 'https://polylang.pro';
+
+		return $http->get( $api_url, $api_query );
 	}
 
 }

--- a/src/Plugins/PolylangPro.php
+++ b/src/Plugins/PolylangPro.php
@@ -27,8 +27,12 @@ class PolylangPro extends AbstractEddPlugin {
 			'license'    => getenv( 'POLYLANG_PRO_KEY' ),
 			'item_name'  => 'Polylang Pro',
 			'url'        => getenv( 'POLYLANG_PRO_URL' ),
-			'version'    => $this->version,
 		);
+
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version ) {
+			$api_query['version'] = $this->version;
+		}
 
 		$api_url = 'https://polylang.pro';
 

--- a/src/Plugins/PolylangPro.php
+++ b/src/Plugins/PolylangPro.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use UnexpectedValueException;
 
 /**
  * PolylangPro class.
@@ -17,6 +18,7 @@ class PolylangPro extends AbstractEddPlugin {
 	/**
 	 * Get the download URL for this plugin.
 	 *
+	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
 	public function getDownloadUrl() {
@@ -28,6 +30,13 @@ class PolylangPro extends AbstractEddPlugin {
 			'url'        => getenv( 'POLYLANG_PRO_URL' ),
 			'version'    => $this->version,
 		) ), true );
+
+		if ( ! is_array( $response ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a JSON object from API for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
 		return $this->extractDownloadUrl( $response );
 	}

--- a/src/Plugins/PolylangPro.php
+++ b/src/Plugins/PolylangPro.php
@@ -8,7 +8,6 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
-use UnexpectedValueException;
 
 /**
  * PolylangPro class.
@@ -16,29 +15,20 @@ use UnexpectedValueException;
 class PolylangPro extends AbstractEddPlugin {
 
 	/**
-	 * Get the download URL for this plugin.
+	 * Get the download URL for this plugin from its API.
 	 *
-	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
-	public function getDownloadUrl() {
-		$http     = new Http();
-		$response = json_decode( $http->get( 'https://polylang.pro', array(
+	protected function getDownloadUrlFromApi() {
+		$http = new Http();
+
+		return $http->get( 'https://polylang.pro', array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'POLYLANG_PRO_KEY' ),
 			'item_name'  => 'Polylang Pro',
 			'url'        => getenv( 'POLYLANG_PRO_URL' ),
 			'version'    => $this->version,
-		) ), true );
-
-		if ( ! is_array( $response ) ) {
-			throw new UnexpectedValueException( sprintf(
-				'Expected a JSON object from API for package %s',
-				'junaidbhura/' . $this->slug
-			) );
-		}
-
-		return $this->extractDownloadUrl( $response );
+		) );
 	}
 
 }

--- a/src/Plugins/PolylangPro.php
+++ b/src/Plugins/PolylangPro.php
@@ -21,7 +21,7 @@ class PolylangPro extends AbstractEddPlugin {
 	 */
 	public function getDownloadUrl() {
 		$http     = new Http();
-		$response = json_decode( $http->post( 'https://polylang.pro', array(
+		$response = json_decode( $http->get( 'https://polylang.pro', array(
 			'edd_action' => 'get_version',
 			'license'    => getenv( 'POLYLANG_PRO_KEY' ),
 			'item_name'  => 'Polylang Pro',

--- a/src/Plugins/PublishPressPro.php
+++ b/src/Plugins/PublishPressPro.php
@@ -106,13 +106,17 @@ class PublishPressPro extends AbstractEddPlugin {
 
 		$http = new Http();
 
-		return $http->get( 'https://publishpress.com', array(
+		$api_query = array(
 			'edd_action' => 'get_version',
 			'license'    => $license,
 			'item_id'    => $id,
 			'url'        => $url,
 			'version'    => $this->version,
-		) );
+		);
+
+		$api_url = 'https://publishpress.com';
+
+		return $http->get( $api_url, $api_query );
 	}
 
 }

--- a/src/Plugins/PublishPressPro.php
+++ b/src/Plugins/PublishPressPro.php
@@ -111,8 +111,12 @@ class PublishPressPro extends AbstractEddPlugin {
 			'license'    => $license,
 			'item_id'    => $id,
 			'url'        => $url,
-			'version'    => $this->version,
 		);
+
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version ) {
+			$api_query['version'] = $this->version;
+		}
 
 		$api_url = 'https://publishpress.com';
 

--- a/src/Plugins/PublishPressPro.php
+++ b/src/Plugins/PublishPressPro.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -28,6 +29,8 @@ class PublishPressPro extends AbstractEddPlugin {
 	/**
 	 * Get the download URL for this plugin.
 	 *
+	 * @throws InvalidArgumentException If the package is unsupported.
+	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
 	public function getDownloadUrl() {
@@ -89,7 +92,7 @@ class PublishPressPro extends AbstractEddPlugin {
 				break;
 
 			default:
-				throw new UnexpectedValueException( sprintf(
+				throw new InvalidArgumentException( sprintf(
 					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
 					'junaidbhura/' . $this->slug
 				) );
@@ -111,6 +114,13 @@ class PublishPressPro extends AbstractEddPlugin {
 			'url'        => $url,
 			'version'    => $this->version,
 		) ), true );
+
+		if ( ! is_array( $response ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a JSON object from API for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
 		return $this->extractDownloadUrl( $response );
 	}

--- a/src/Plugins/PublishPressPro.php
+++ b/src/Plugins/PublishPressPro.php
@@ -9,7 +9,6 @@ namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
 use InvalidArgumentException;
-use UnexpectedValueException;
 
 /**
  * PublishPressPro class.
@@ -27,13 +26,12 @@ class PublishPressPro extends AbstractEddPlugin {
 	}
 
 	/**
-	 * Get the download URL for this plugin.
+	 * Get the download URL for this plugin from its API.
 	 *
 	 * @throws InvalidArgumentException If the package is unsupported.
-	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
-	public function getDownloadUrl() {
+	protected function getDownloadUrlFromApi() {
 		$id  = 0;
 		$env = null;
 		/**
@@ -106,23 +104,15 @@ class PublishPressPro extends AbstractEddPlugin {
 			$url     = ( getenv( "PUBLISHPRESS_{$env}_PRO_URL" ) ?: $url );
 		}
 
-		$http     = new Http();
-		$response = json_decode( $http->get( 'https://publishpress.com', array(
+		$http = new Http();
+
+		return $http->get( 'https://publishpress.com', array(
 			'edd_action' => 'get_version',
 			'license'    => $license,
 			'item_id'    => $id,
 			'url'        => $url,
 			'version'    => $this->version,
-		) ), true );
-
-		if ( ! is_array( $response ) ) {
-			throw new UnexpectedValueException( sprintf(
-				'Expected a JSON object from API for package %s',
-				'junaidbhura/' . $this->slug
-			) );
-		}
-
-		return $this->extractDownloadUrl( $response );
+		) );
 	}
 
 }

--- a/src/Plugins/PublishPressPro.php
+++ b/src/Plugins/PublishPressPro.php
@@ -92,7 +92,7 @@ class PublishPressPro extends AbstractEddPlugin {
 			default:
 				throw new InvalidArgumentException( sprintf(
 					'Could not find a matching package for %s. Check the package spelling and that the package is supported',
-					'junaidbhura/' . $this->slug
+					$this->getPackageName()
 				) );
 		}
 

--- a/src/Plugins/WpAiPro.php
+++ b/src/Plugins/WpAiPro.php
@@ -77,13 +77,17 @@ class WpAiPro extends AbstractEddPlugin {
 
 		$http = new Http();
 
-		return $http->get( 'https://www.wpallimport.com', array(
+		$api_query = array(
 			'edd_action' => 'get_version',
 			'license'    => $license,
 			'item_name'  => $name,
 			'url'        => $url,
 			'version'    => $this->version,
-		) );
+		);
+
+		$api_url = 'https://www.wpallimport.com';
+
+		return $http->get( $api_url, $api_query );
 	}
 
 }

--- a/src/Plugins/WpAiPro.php
+++ b/src/Plugins/WpAiPro.php
@@ -8,6 +8,7 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
+use UnexpectedValueException;
 
 /**
  * WpAiPro class.
@@ -27,6 +28,7 @@ class WpAiPro extends AbstractEddPlugin {
 	/**
 	 * Get the download URL for this plugin.
 	 *
+	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
 	public function getDownloadUrl() {
@@ -83,6 +85,13 @@ class WpAiPro extends AbstractEddPlugin {
 			'url'        => $url,
 			'version'    => $this->version,
 		) ), true );
+
+		if ( ! is_array( $response ) ) {
+			throw new UnexpectedValueException( sprintf(
+				'Expected a JSON object from API for package %s',
+				'junaidbhura/' . $this->slug
+			) );
+		}
 
 		return $this->extractDownloadUrl( $response );
 	}

--- a/src/Plugins/WpAiPro.php
+++ b/src/Plugins/WpAiPro.php
@@ -82,8 +82,12 @@ class WpAiPro extends AbstractEddPlugin {
 			'license'    => $license,
 			'item_name'  => $name,
 			'url'        => $url,
-			'version'    => $this->version,
 		);
+
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version ) {
+			$api_query['version'] = $this->version;
+		}
 
 		$api_url = 'https://www.wpallimport.com';
 

--- a/src/Plugins/WpAiPro.php
+++ b/src/Plugins/WpAiPro.php
@@ -8,7 +8,6 @@
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
 use Junaidbhura\Composer\WPProPlugins\Http;
-use UnexpectedValueException;
 
 /**
  * WpAiPro class.
@@ -26,12 +25,11 @@ class WpAiPro extends AbstractEddPlugin {
 	}
 
 	/**
-	 * Get the download URL for this plugin.
+	 * Get the download URL for this plugin from its API.
 	 *
-	 * @throws UnexpectedValueException If the response is invalid.
 	 * @return string
 	 */
-	public function getDownloadUrl() {
+	protected function getDownloadUrlFromApi() {
 		$url     = '';
 		$name    = '';
 		$license = '';
@@ -77,23 +75,15 @@ class WpAiPro extends AbstractEddPlugin {
 			}
 		}
 
-		$http     = new Http();
-		$response = json_decode( $http->get( 'https://www.wpallimport.com', array(
+		$http = new Http();
+
+		return $http->get( 'https://www.wpallimport.com', array(
 			'edd_action' => 'get_version',
 			'license'    => $license,
 			'item_name'  => $name,
 			'url'        => $url,
 			'version'    => $this->version,
-		) ), true );
-
-		if ( ! is_array( $response ) ) {
-			throw new UnexpectedValueException( sprintf(
-				'Expected a JSON object from API for package %s',
-				'junaidbhura/' . $this->slug
-			) );
-		}
-
-		return $this->extractDownloadUrl( $response );
+		) );
 	}
 
 }

--- a/src/Plugins/Wpml.php
+++ b/src/Plugins/Wpml.php
@@ -62,8 +62,12 @@ class Wpml extends AbstractPlugin {
 			'download'         => $packages[ $this->slug ],
 			'user_id'          => getenv( 'WPML_USER_ID' ),
 			'subscription_key' => getenv( 'WPML_KEY' ),
-			'version'          => $this->version,
 		);
+
+		// If no version is specified, we are fetching the latest version.
+		if ( $this->version ) {
+			$api_query['version'] = $this->version;
+		}
 
 		$api_url = 'https://wpml.org/';
 

--- a/src/Plugins/Wpml.php
+++ b/src/Plugins/Wpml.php
@@ -58,12 +58,16 @@ class Wpml extends AbstractPlugin {
 			) );
 		}
 
-		return 'https://wpml.org/?' . http_build_query( array(
+		$api_query = array(
 			'download'         => $packages[ $this->slug ],
 			'user_id'          => getenv( 'WPML_USER_ID' ),
 			'subscription_key' => getenv( 'WPML_KEY' ),
 			'version'          => $this->version,
-		), '', '&' );
+		);
+
+		$api_url = 'https://wpml.org/';
+
+		return $api_url . '?' . http_build_query( $api_query, '', '&' );
 	}
 
 }

--- a/src/Plugins/Wpml.php
+++ b/src/Plugins/Wpml.php
@@ -57,7 +57,12 @@ class Wpml extends AbstractPlugin {
 			) );
 		}
 
-		return 'https://wpml.org/?download=' . $packages[ $this->slug ] . '&user_id=' . getenv( 'WPML_USER_ID' ) . '&subscription_key=' . getenv( 'WPML_KEY' ) . '&version=' . $this->version;
+		return 'https://wpml.org/?' . http_build_query( array(
+			'download'         => $packages[ $this->slug ],
+			'user_id'          => getenv( 'WPML_USER_ID' ),
+			'subscription_key' => getenv( 'WPML_KEY' ),
+			'version'          => $this->version,
+		), '', '&' );
 	}
 
 }

--- a/src/Plugins/Wpml.php
+++ b/src/Plugins/Wpml.php
@@ -54,7 +54,7 @@ class Wpml extends AbstractPlugin {
 		if ( ! array_key_exists( $this->slug, $packages ) ) {
 			throw new InvalidArgumentException( sprintf(
 				'Could not find a matching package for %s. Check the package spelling and that the package is supported',
-				'junaidbhura/' . $this->slug
+				$this->getPackageName()
 			) );
 		}
 

--- a/src/Plugins/Wpml.php
+++ b/src/Plugins/Wpml.php
@@ -7,7 +7,7 @@
 
 namespace Junaidbhura\Composer\WPProPlugins\Plugins;
 
-use UnexpectedValueException;
+use InvalidArgumentException;
 
 /**
  * Wpml class.
@@ -27,6 +27,7 @@ class Wpml extends AbstractPlugin {
 	/**
 	 * Get the download URL for this plugin.
 	 *
+	 * @throws InvalidArgumentException If the package is unsupported.
 	 * @return string
 	 */
 	public function getDownloadUrl() {
@@ -51,7 +52,7 @@ class Wpml extends AbstractPlugin {
 		);
 
 		if ( ! array_key_exists( $this->slug, $packages ) ) {
-			throw new UnexpectedValueException( sprintf(
+			throw new InvalidArgumentException( sprintf(
 				'Could not find a matching package for %s. Check the package spelling and that the package is supported',
 				'junaidbhura/' . $this->slug
 			) );


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing page](https://github.com/junaidbhura/composer-wp-pro-plugins/blob/master/CONTRIBUTING.md).
- [x] Issues: #54, #55, #56, #57
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code has proper inline documentation.

## Draft 2 — 2023-03-15

### Description

Follow-up to #52 and alternative to the initial draft (see below).

Primary focus is improving error handling by validating the response from cURL requests, validating the decoded/unserialized response bodies, and simplifying the logic between plugins.

### How has this been tested?

I'm testing this on client projects that use ACF Pro, ACF Extended Pro, PublishPress Pro, Gravity Forms, Polylang Pro, and WPML.

### Screenshots

![Screen capture of the originally proposed error example "cURL error (22): The requested URL returned error: 404"](https://user-images.githubusercontent.com/29353/225478853-2953bed8-8aae-4ca1-867f-42ebe350defa.png)

![Screen capture of the latest proposed error example "JSON Error: Expected a data structure"](https://github.com/junaidbhura/composer-wp-pro-plugins/assets/29353/546e794f-acd5-4fd7-9cc8-5be1aa174514)


### Types of changes

- Plugins:
	- ACF Pro, Gravity Forms, WPML: Change URL formatting to use `http_build_query()` to improve readability and reduce risk of mistakes.
	- ACF Extended Pro, Gravity Forms, Polylang Pro: Change HTTP request method to use `GET` instead of `POST` to better match the verb of the request and for consistency between the other downloader. Both Gravity Forms' API and Easy Digital Downloads' API support `GET` requests.
	- Ninja Forms, PublishPress Pro, WPML: Throw `InvalidArgumentException` instead of `UnexpectedValueException` when dealing with an unsupported package.
	- EDD Plugins, Gravity Forms: Throw `UnexpectedValueException` if the decoded/unserialized API response is not an array.
	- EDD Plugins: Replaced `getDownloadUrl()` with a new protected method `getDownloadUrlFromApi()` that only handles the request for the download URL response object.
- `AbstractEddPlugin`:
	- Replaced `extractDownloadUrl()` with `getDownloadUrl()` that retrieves the response to parse from the plugin's `getDownloadUrlFromApi()`.
	- Wrapped requests with `Http` in a try/catch to intercept cURL exceptions and wrap them in a plugin-aware exception.
- `Http`:
	- Added protected method `request()` to aggregate the execution of the request, handling of the response, and closing of the cURL handler.
	- Added cURL option `CURLOPT_FAILONERROR` to fail if the response is >= 400.
	- Throw `RuntimeException` if the request failed.
	- Compile URL in GET request earlier to organize cURL options similarly to POST request.
	- Use booleans intead of integers for cURL options.

---

<details>
<summary><h2>Draft 1 — 2023-03-07</h2></summary>

### Description

Follow-up to #52.

Fixed the PSR-4 file name for `Wpml` class, for the sake of testing.

Improve checks on HTTP response. Check if status code is OK (200) and if the body is an array, throw exceptions if not with an excerpt of the response body for aid with debugging.

Expanding upon #47, improved Gravity Forms to check if download version matches the package's version with support for either available download: the "main version" (`download_url`) or the "latest version" (`download_url_latest`). For example:

* `version`: `2.7.2` (`PARADIGM.MAJOR.MINOR`)
* `version_latest`: `2.7.2.1` (`PARADIGM.MAJOR.MINOR.PATCH`)

As of 2023-03-08, this code sort of works but is not completely tested/vetted, nor is it the best design, and some of it should be split into their own pull requests.

If we drop support for Composer 1, a lot of this proposed code can be simplified to take advantage of Composer 2's utilities.

I'm open to comments, suggestions, and contributions.

### How has this been tested?

I'm testing this on client projects that use ACF Pro, ~~ACF Extended Pro~~, ~~PublishPress Pro~~, Gravity Forms, Polylang Pro, and WPML.

### Types of changes

* Change URL formatting (for ACF, Gravity Forms, WPML) to use `http_build_query()` to improve readability and reduce risk of mistakes.
* Change HTTP request method (for ACF Extended, Gravity Forms, Polylang) to use `GET` instead of `POST` to better match the verb of the request and for consistency between the other downloader. Both Gravity Forms' API and Easy Digital Downloads' API support `GET` requests.
* Refactored `Http` class to store last response body and headers, allow parsing of body through callback, and finding of status code and message (based on Composer 2's `Response`, `RemoteFileSystem`, and `HttpDownloader`).
* Use Composer's `Semver` to check Gravity Forms versions and throw an exception if we download the incorrect version.

</details>